### PR TITLE
Enhance API data fetching and slug generation for nested structures

### DIFF
--- a/server/api/__sitemap__/urls.ts
+++ b/server/api/__sitemap__/urls.ts
@@ -4,7 +4,7 @@ import { generateSlug } from "~/utils/format";
 export default defineSitemapEventHandler(async () => {
   // Fetch all documents in parallel
   const [pagesResponse, articlesResponse, recipesResponse] = await Promise.all([
-    $fetch("https://admin.journalducuistot.fr/api/pages?populate=parent"),
+    $fetch("https://admin.journalducuistot.fr/api/pages?populate[parent][populate][0]=parent&pagination[pageSize]=100&status=published"),
     $fetch("https://admin.journalducuistot.fr/api/articles?pagination[pageSize]=100&populate=category"),
     $fetch("https://admin.journalducuistot.fr/api/recipes?pagination[pageSize]=100")
   ]) as any[];

--- a/server/routes/rss.xml.ts
+++ b/server/routes/rss.xml.ts
@@ -8,7 +8,7 @@ export default defineEventHandler(async (event) => {
   });
 
   const { data: pages } = await $fetch(
-    "https://admin.journalducuistot.fr/api/pages?populate=*"
+    "https://admin.journalducuistot.fr/api/pages?populate[0]=parent&populate[1]=parent.parent&populate[2]=seoMeta&pagination[pageSize]=100&pagination[page]=1&status=published"
   );
 
   const { data: articles } = await $fetch(

--- a/types/strapiMeta.d.ts
+++ b/types/strapiMeta.d.ts
@@ -90,6 +90,23 @@ export type Tag = {
   locale?: string;
 };
 
+// Type for nested parent structure
+export type NestedParent = {
+  id?: number;
+  name?: string;
+  title?: string;
+  slug?: string;
+  /** Format: date-time */
+  createdAt?: string;
+  /** Format: date-time */
+  updatedAt?: string;
+  /** Format: date-time */
+  publishedAt?: string;
+  documentId?: string;
+  locale?: string;
+  parent?: NestedParent; // Recursive type for nested parents
+};
+
 export type Recipe = {
   id?: number;
   title?: string;
@@ -111,6 +128,7 @@ export type Recipe = {
   /** Format: date-time */
   publishedAt?: string;
   locale?: string;
+  parent?: NestedParent; // Add parent field
 };
 
 export type Article = {
@@ -130,4 +148,5 @@ export type Article = {
   locale?: string;
   prev?: Article;
   next?: Article;
+  parent?: NestedParent; // Add parent field
 };

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -1,3 +1,5 @@
+import type { NestedParent } from '~/types/strapiMeta';
+
 function capitalize(sentence: string): string {
   return sentence
     .split(" ")
@@ -12,9 +14,63 @@ export const truncate = (str: string, n: number) => {
   return str?.toString().replace(new RegExp(`(.{${n - 1}})..+`), "$1...");
 };
 
-export const generateSlug = (str: string, parent: any) => {
-  return parent?.slug
-    ? `/${parent?.slug}/${str}`
-    : `/${str}`;
+/**
+ * Extracts the full parent hierarchy as an array
+ * @param parent - The parent object (can be nested)
+ * @returns Array of parent objects from root to immediate parent
+ */
+export const getParentHierarchy = (parent: NestedParent | null | undefined): NestedParent[] => {
+  if (!parent?.slug) {
+    return [];
+  }
+
+  const hierarchy: NestedParent[] = [];
+  let currentParent: NestedParent | null | undefined = parent;
+
+  while (currentParent?.slug) {
+    hierarchy.unshift(currentParent);
+    currentParent = currentParent.parent;
+  }
+
+  return hierarchy;
+};
+
+/**
+ * Generates a slug path by recursively traversing the parent hierarchy
+ * @param str - The current item's slug
+ * @param parent - The parent object (can be nested)
+ * @returns The full path from root to current item
+ * 
+ * @example
+ * // For nested data like:
+ *  {
+ *    slug: "saisir-viande-parfaitement",
+ *   parent: {
+ *      slug: "methodes-de-cuisson",
+ *      parent: {
+ *        slug: "techniques-culinaires"
+ *      }
+ *    }
+ *  }
+ *  generateSlug("saisir-viande-parfaitement", parent)
+ * // Returns: "/techniques-culinaires/methodes-de-cuisson/saisir-viande-parfaitement"
+ */
+export const generateSlug = (str: string, parent: NestedParent | null | undefined): string => {
+  if (!parent?.slug) {
+    return `/${str}`;
+  }
+
+  // Recursively build the path from root to current
+  const buildParentPath = (currentParent: NestedParent | null | undefined): string => {
+    if (!currentParent?.slug) {
+      return '';
+    }
+
+    const parentPath = buildParentPath(currentParent.parent);
+    return parentPath ? `${parentPath}/${currentParent.slug}` : currentParent.slug;
+  };
+
+  const parentPath = buildParentPath(parent);
+  return parentPath ? `/${parentPath}/${str}` : `/${str}`;
 };
 


### PR DESCRIPTION
- Updated API calls in sitemap and RSS feed to include nested parent population and pagination for improved data retrieval.
- Introduced a new type definition for nested parent structures in strapiMeta.d.ts to support hierarchical relationships.
- Refactored slug generation logic to recursively build paths based on parent hierarchy, ensuring accurate URL construction for nested items.