### PR TITLE
Dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,3 +187,41 @@ pnpm preview          # Preview production build
 - **`app.vue:11` has `@todo`** — Schema.org identity selection (Organization vs Person) still pending.
 
 See `app/components/AGENTS.md` for the component domain guide and `server/AGENTS.md` for Nitro routes.
+
+---
+
+## NOTION TRACKING
+
+> Suivi du projet dans Notion, DB "Client project".
+
+### Page projet
+
+- **Page Notion**: https://app.notion.com/p/Journal-du-Cuistot-358827538c8a81aabd46eb6ccbf291b2
+- **Page ID**: `35882753-8c8a-81aa-bd46-eb6ccbf291b2`
+
+### Mettre a jour la page
+
+```bash
+# Lire la page (statut, notes)
+ntn api v1/pages/35882753-8c8a-81aa-bd46-eb6ccbf291b2
+
+# Mettre a jour le statut et les notes
+ntn api v1/pages/35882753-8c8a-81aa-bd46-eb6ccbf291b2 -X PATCH properties:='{"Status":{"status":{"name":"Dev"}},"Notes":{"rich_text":[{"text":{"content":"..."}}]}}'
+
+# Ajouter un block au body (heading_2, paragraph, bulleted_list_item...)
+ntn api v1/blocks/35882753-8c8a-81aa-bd46-eb6ccbf291b2/children -X PATCH 'children[0][type]=heading_2' 'children[0][heading_2][rich_text][0][text][content]=Stat'
+```
+
+### Ajouter une tache a la todo globale (DB Taches)
+
+Toute tache a faire se cree dans la DB Taches (`35782753-8c8a-8165-9068-eb0a4899acc6`) avec la relation `Projet` vers cette page. Elle apparait alors sur le kanban du projet.
+
+```bash
+ntn api v1/pages -X POST \
+  parent[data_source_id]=35782753-8c8a-8108-99cd-000b85e41234 \
+  properties:='{"Name":{"title":[{"text":{"content":"Titre de la tache"}}]},"Statut":{"status":{"name":"À faire"}},"Projet":{"relation":[{"id":"35882753-8c8a-81aa-bd46-eb6ccbf291b2"}]},"Priorité":{"select":{"name":"Moyenne"}},"Type":{"select":{"name":"Projet"}}}'
+```
+
+Statuts: À faire, En cours, En attente, Fait, Annulé. Priorites: Urgent, Haute, Moyenne, Basse. Types: Projet, Opérationnel, Contenu, Administratif.
+ 
+Prochaine tache connue: audit SEO avec nuxt-seo-pro sur le nouveau CMS (voir contexte dans les Notes de la page).

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -45,7 +45,10 @@ pnpm task:strapi-extract
 | Path | Database | Migrations |
 |------|----------|------------|
 | `pnpm dev:cms` | `.data/db/sqlite.db` (libSQL) | `scripts/migrate-local.ts` before Nuxt |
+| `pnpm dev:infra` (repo root) | Alchemy dev worker + bindings | Use CMS URL from Alchemy (not only `:3001`) for Workers AI |
 | `pnpm alchemy deploy` (repo root) | Cloudflare D1 | Drizzle migrations in `server/db/migrations/sqlite/` |
+
+**Editor AI (`POST /api/completion`)** needs the Workers AI binding (`env.AI`). Bindings live in `nuxt.config.ts` (`nitro.cloudflare.wrangler`); dev writes `.wrangler/dev/wrangler.json` for Wrangler `getPlatformProxy`. Requires `wrangler` (repo devDependency) and Cloudflare auth. Alchemy: `Cloudflare.AI.Gateway` + `Cloudflare.Workers.AI()` in `infra/workers.ts` — redeploy after infra changes.
 
 ## Admin seeder
 

--- a/apps/cms/app/assets/css/main.css
+++ b/apps/cms/app/assets/css/main.css
@@ -155,7 +155,6 @@
     box-shadow: none !important;
     border-radius: 0 !important;
     --tw-ring-shadow: 0 0 #0000 !important;
-    ring: none;
   }
 
   .cms-markdown-editor--preview .cms-editor-grid-column {
@@ -190,6 +189,31 @@
   .cms-markdown-editor--preview .cms-editor-callout__content {
     @apply py-4;
   }
+
+  /* AI review: reformulation original selection only */
+  .cms-markdown-editor .ProseMirror .ai-review-old {
+    background-color: color-mix(in oklab, var(--ui-error) 14%, transparent);
+    border-radius: 2px;
+  }
+
+  /* Proofread: only the wrong token — not the whole paragraph */
+  .cms-markdown-editor .ProseMirror .ai-review-error {
+    background-color: color-mix(in oklab, var(--ui-warning) 28%, transparent);
+    border-bottom: 2px wavy color-mix(in oklab, var(--ui-error) 85%, transparent);
+    border-radius: 2px;
+  }
+
+  .ai-review-old-inline {
+    background-color: color-mix(in oklab, var(--ui-warning) 22%, transparent);
+    text-decoration: line-through;
+    text-decoration-color: color-mix(in oklab, var(--ui-error) 70%, transparent);
+  }
+
+  .ai-review-new-text {
+    background-color: color-mix(in oklab, var(--ui-success) 16%, transparent);
+    border-radius: 2px;
+  }
+
 }
 
 @theme static {

--- a/apps/cms/app/assets/css/main.css
+++ b/apps/cms/app/assets/css/main.css
@@ -199,7 +199,8 @@
   /* Proofread: only the wrong token — not the whole paragraph */
   .cms-markdown-editor .ProseMirror .ai-review-error {
     background-color: color-mix(in oklab, var(--ui-warning) 28%, transparent);
-    border-bottom: 2px wavy color-mix(in oklab, var(--ui-error) 85%, transparent);
+    text-decoration: underline wavy color-mix(in oklab, var(--ui-error) 85%, transparent);
+    text-underline-offset: 2px;
     border-radius: 2px;
   }
 

--- a/apps/cms/app/assets/css/main.css
+++ b/apps/cms/app/assets/css/main.css
@@ -214,6 +214,25 @@
     border-radius: 2px;
   }
 
+  .ai-review-skeleton {
+    background: linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--ui-muted) 18%, transparent) 0%,
+      color-mix(in oklab, var(--ui-muted) 38%, transparent) 45%,
+      color-mix(in oklab, var(--ui-muted) 18%, transparent) 90%
+    );
+    background-size: 220% 100%;
+    animation: ai-review-shimmer 1.15s ease-in-out infinite;
+  }
+}
+
+@keyframes ai-review-shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
 }
 
 @theme static {

--- a/apps/cms/app/components/content/EditorAiReviewPanel.vue
+++ b/apps/cms/app/components/content/EditorAiReviewPanel.vue
@@ -1,0 +1,378 @@
+<script setup lang="ts">
+import type { EditorCompletionMode } from '#shared/editor-completion-modes'
+import type { AiReviewPanelModel } from '~/types/editor-ai-review'
+
+const props = defineProps<{
+  review: AiReviewPanelModel
+  busy?: boolean
+}>()
+
+const emit = defineEmits<{
+  accept: []
+  refuse: []
+  redo: []
+  'update:activeVariant': [index: number]
+  'update:proofreadDecision': [id: string, decision: 'accept' | 'reject' | 'pending']
+}>()
+
+const panelRef = ref<HTMLElement | null>(null)
+const panelSize = ref({ width: 360, height: 200 })
+
+const title = computed(() => {
+  switch (props.review.kind) {
+    case 'continue':
+      return 'Suite proposée'
+    case 'proofread':
+      return 'Orthographe'
+    case 'reformulate':
+      return 'Reformulation'
+    default: {
+      const _exhaustive: never = props.review.kind
+      return _exhaustive
+    }
+  }
+})
+
+const modeLabel = computed(() => {
+  const labels: Partial<Record<EditorCompletionMode, string>> = {
+    continue: 'Continuer',
+    fix: 'Orthographe',
+    extend: 'Développer',
+    reduce: 'Raccourcir',
+    simplify: 'Simplifier',
+    summarize: 'Résumer',
+    translate: 'Traduire',
+  }
+  return labels[props.review.mode] ?? props.review.mode
+})
+
+const activeText = computed(() =>
+  props.review.variants[props.review.activeVariant] ?? '',
+)
+
+const applyProofreadCount = computed(() =>
+  props.review.proofread.filter(item => item.decision !== 'reject').length,
+)
+
+const rejectedProofreadCount = computed(() =>
+  props.review.proofread.filter(item => item.decision === 'reject').length,
+)
+
+type AnnotatedPart
+  = | { kind: 'text', text: string }
+    | {
+      kind: 'error'
+      id: string
+      original: string
+      suggestion: string
+      message: string
+      decision: 'pending' | 'accept' | 'reject'
+    }
+
+const annotatedParts = computed((): AnnotatedPart[] => {
+  const text = props.review.original
+  const items = [...props.review.proofread].sort((a, b) => a.start - b.start)
+  if (!items.length) {
+    return [{ kind: 'text', text }]
+  }
+
+  const parts: AnnotatedPart[] = []
+  let cursor = 0
+  for (const item of items) {
+    if (item.start > cursor) {
+      parts.push({ kind: 'text', text: text.slice(cursor, item.start) })
+    }
+    parts.push({
+      kind: 'error',
+      id: item.id,
+      original: item.original,
+      suggestion: item.suggestion,
+      message: item.message,
+      decision: item.decision,
+    })
+    cursor = item.end
+  }
+  if (cursor < text.length) {
+    parts.push({ kind: 'text', text: text.slice(cursor) })
+  }
+  return parts
+})
+
+const GAP = 8
+const MARGIN = 12
+const PANEL_WIDTH = 380
+
+const panelStyle = computed(() => {
+  const anchor = props.review.anchor
+  if (!anchor || !import.meta.client) {
+    return {
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      width: `min(${PANEL_WIDTH}px, calc(100vw - ${MARGIN * 2}px))`,
+    }
+  }
+
+  const width = Math.min(PANEL_WIDTH, window.innerWidth - MARGIN * 2)
+  const height = panelSize.value.height
+  const spaceBelow = window.innerHeight - anchor.bottom - MARGIN
+  const placeBelow = spaceBelow >= Math.min(height, 160) || anchor.top < height + MARGIN
+
+  let top = placeBelow ? anchor.bottom + GAP : anchor.top - height - GAP
+  top = Math.max(MARGIN, Math.min(top, window.innerHeight - height - MARGIN))
+
+  let left = anchor.left
+  left = Math.max(MARGIN, Math.min(left, window.innerWidth - width - MARGIN))
+
+  return {
+    top: `${Math.round(top)}px`,
+    left: `${Math.round(left)}px`,
+    width: `${Math.round(width)}px`,
+    transform: 'none',
+  }
+})
+
+watch(
+  () => [props.review.kind, props.review.status, props.review.proofread.length, props.review.variants.join('\0')] as const,
+  async () => {
+    await nextTick()
+    const el = panelRef.value
+    if (!el) {
+      return
+    }
+    panelSize.value = {
+      width: el.offsetWidth,
+      height: el.offsetHeight,
+    }
+  },
+  { flush: 'post', immediate: true },
+)
+
+function setVariant(index: number) {
+  emit('update:activeVariant', index)
+}
+
+function setDecision(id: string, decision: 'accept' | 'reject' | 'pending') {
+  emit('update:proofreadDecision', id, decision)
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      ref="panelRef"
+      class="ai-review-panel fixed z-50 max-h-[min(70vh,32rem)] overflow-y-auto rounded-lg border border-default bg-elevated p-3 shadow-lg sm:p-4"
+      role="dialog"
+      :aria-label="title"
+      :style="panelStyle"
+    >
+      <div class="mb-3 flex flex-wrap items-center gap-2">
+        <UBadge
+          color="primary"
+          variant="subtle"
+          size="sm"
+        >
+          {{ title }}
+        </UBadge>
+        <span
+          v-if="modeLabel !== title"
+          class="text-xs text-muted"
+        >{{ modeLabel }}</span>
+        <UBadge
+          v-if="review.status === 'streaming'"
+          color="info"
+          variant="subtle"
+          size="sm"
+        >
+          Analyse…
+        </UBadge>
+        <div class="ml-auto flex flex-wrap items-center gap-1.5">
+          <UButton
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            icon="i-lucide-rotate-ccw"
+            :disabled="busy"
+            @click="emit('redo')"
+          >
+            Relancer
+          </UButton>
+          <UButton
+            size="xs"
+            color="neutral"
+            variant="soft"
+            icon="i-lucide-x"
+            @click="emit('refuse')"
+          >
+            Refuser
+          </UButton>
+          <UButton
+            size="xs"
+            color="primary"
+            variant="solid"
+            icon="i-lucide-check"
+            :disabled="busy || review.status === 'streaming' || (review.kind !== 'proofread' && !activeText.trim())"
+            @click="emit('accept')"
+          >
+            Accepter
+          </UButton>
+        </div>
+      </div>
+
+      <!-- Reformulation: two alternatives -->
+      <div
+        v-if="review.kind === 'reformulate'"
+        class="mb-1 grid gap-2 sm:grid-cols-2"
+      >
+        <button
+          v-for="(variant, index) in review.variants"
+          :key="index"
+          type="button"
+          class="rounded-md border px-3 py-2 text-left transition-colors"
+          :class="index === review.activeVariant
+            ? 'border-primary bg-primary/10 ring-1 ring-primary/30'
+            : 'border-default bg-default hover:bg-elevated'"
+          @click="setVariant(index)"
+        >
+          <div class="mb-1 flex items-center justify-between gap-2">
+            <span class="text-[11px] font-medium uppercase tracking-wide text-muted">
+              Proposition {{ index + 1 }}
+            </span>
+            <UBadge
+              v-if="index === review.activeVariant"
+              color="primary"
+              variant="subtle"
+              size="sm"
+            >
+              Choisie
+            </UBadge>
+          </div>
+          <p class="max-h-28 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-default">
+            <span class="ai-review-new-text">{{ variant || (review.status === 'streaming' ? '…' : 'Vide') }}</span>
+          </p>
+        </button>
+      </div>
+
+      <!-- Continue / single proposal -->
+      <div
+        v-else-if="review.kind === 'continue'"
+        class="grid gap-2 sm:grid-cols-2"
+      >
+        <div class="rounded-md border border-error/30 bg-error/5 px-3 py-2">
+          <p class="mb-1 text-[11px] font-medium uppercase tracking-wide text-error">
+            Contexte
+          </p>
+          <p class="max-h-24 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-muted">
+            {{ review.original.slice(-280) || '(début de document)' }}
+          </p>
+        </div>
+        <div class="rounded-md border border-success/30 bg-success/5 px-3 py-2">
+          <p class="mb-1 text-[11px] font-medium uppercase tracking-wide text-success">
+            Suite
+          </p>
+          <p class="max-h-24 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-default">
+            <span class="ai-review-new-text">{{ activeText || (review.status === 'streaming' ? '…' : 'Vide') }}</span>
+          </p>
+        </div>
+      </div>
+
+      <!-- Proofread checklist -->
+      <div
+        v-else
+        class="space-y-3"
+      >
+        <p class="text-xs text-muted">
+          Corrections FR-FR uniquement. Orange = suggestion · Ignorer pour laisser le texte.
+        </p>
+
+        <div class="rounded-md border border-default bg-default px-3 py-2">
+          <p class="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-muted">
+            Aperçu
+          </p>
+          <p class="text-sm leading-relaxed text-default">
+            <template
+              v-for="(part, index) in annotatedParts"
+              :key="index"
+            >
+              <span v-if="part.kind === 'text'">{{ part.text }}</span>
+              <button
+                v-else
+                type="button"
+                class="mx-0.5 inline rounded px-0.5 transition-colors"
+                :class="{
+                  'bg-warning/25 underline decoration-wavy decoration-warning': part.decision === 'pending',
+                  'bg-success/25 text-success': part.decision === 'accept',
+                  'bg-muted/30 text-muted line-through': part.decision === 'reject',
+                }"
+                :title="part.message"
+                @click="setDecision(part.id, part.decision === 'accept' ? 'pending' : 'accept')"
+              >
+                <span v-if="part.decision === 'accept'">{{ part.suggestion }}</span>
+                <span v-else>{{ part.original }}</span>
+              </button>
+            </template>
+          </p>
+        </div>
+
+        <p
+          v-if="!review.proofread.length && review.status === 'ready'"
+          class="text-sm text-muted"
+        >
+          Aucune faute détectée en français.
+        </p>
+
+        <ul
+          v-else-if="review.proofread.length"
+          class="max-h-52 space-y-2 overflow-y-auto"
+        >
+          <li
+            v-for="(item, index) in review.proofread"
+            :key="item.id"
+            class="flex flex-wrap items-start gap-2 rounded-md border border-default bg-default px-3 py-2"
+            :class="{
+              'opacity-55': item.decision === 'reject',
+              'ring-1 ring-success/40': item.decision === 'accept',
+            }"
+          >
+            <span class="mt-0.5 size-5 shrink-0 rounded-full bg-elevated text-center text-[11px] font-medium leading-5 text-muted">
+              {{ index + 1 }}
+            </span>
+            <div class="min-w-0 flex-1">
+              <p class="text-sm">
+                <span class="rounded bg-warning/20 px-1 line-through decoration-warning">{{ item.original }}</span>
+                <span class="mx-1 text-muted">→</span>
+                <span class="rounded bg-success/20 px-1 font-medium text-success">{{ item.suggestion }}</span>
+              </p>
+              <p class="mt-0.5 text-xs text-muted">
+                {{ item.message }}
+              </p>
+            </div>
+            <div class="flex shrink-0 gap-1">
+              <UButton
+                size="xs"
+                color="success"
+                :variant="item.decision === 'accept' ? 'solid' : 'soft'"
+                label="Corriger"
+                @click="setDecision(item.id, item.decision === 'accept' ? 'pending' : 'accept')"
+              />
+              <UButton
+                size="xs"
+                color="neutral"
+                :variant="item.decision === 'reject' ? 'solid' : 'ghost'"
+                label="Ignorer"
+                @click="setDecision(item.id, item.decision === 'reject' ? 'pending' : 'reject')"
+              />
+            </div>
+          </li>
+        </ul>
+
+        <p
+          v-if="review.proofread.length"
+          class="text-xs text-muted"
+        >
+          {{ applyProofreadCount }} correction(s) · {{ rejectedProofreadCount }} ignorée(s).
+        </p>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/apps/cms/app/components/content/EditorAiReviewPanel.vue
+++ b/apps/cms/app/components/content/EditorAiReviewPanel.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{
 }>()
 
 const panelRef = ref<HTMLElement | null>(null)
-const panelSize = ref({ width: 360, height: 200 })
+const panelSize = ref({ width: 640, height: 200 })
 
 const title = computed(() => {
   switch (props.review.kind) {
@@ -49,6 +49,8 @@ const modeLabel = computed(() => {
 const activeText = computed(() =>
   props.review.variants[props.review.activeVariant] ?? '',
 )
+
+const isStreaming = computed(() => props.review.status === 'streaming')
 
 const applyProofreadCount = computed(() =>
   props.review.proofread.filter(item => item.decision !== 'reject').length,
@@ -98,9 +100,9 @@ const annotatedParts = computed((): AnnotatedPart[] => {
   return parts
 })
 
-const GAP = 8
+const GAP = 4
 const MARGIN = 12
-const PANEL_WIDTH = 380
+const FALLBACK_WIDTH = 720
 
 const panelStyle = computed(() => {
   const anchor = props.review.anchor
@@ -109,14 +111,16 @@ const panelStyle = computed(() => {
       top: '50%',
       left: '50%',
       transform: 'translate(-50%, -50%)',
-      width: `min(${PANEL_WIDTH}px, calc(100vw - ${MARGIN * 2}px))`,
+      width: `min(${FALLBACK_WIDTH}px, calc(100vw - ${MARGIN * 2}px))`,
     }
   }
 
-  const width = Math.min(PANEL_WIDTH, window.innerWidth - MARGIN * 2)
+  const available = Math.max(0, anchor.right - anchor.left)
+  const maxViewport = window.innerWidth - MARGIN * 2
+  const width = Math.min(Math.max(available, 320), maxViewport)
   const height = panelSize.value.height
   const spaceBelow = window.innerHeight - anchor.bottom - MARGIN
-  const placeBelow = spaceBelow >= Math.min(height, 160) || anchor.top < height + MARGIN
+  const placeBelow = spaceBelow >= Math.min(height, 140) || anchor.top < height + MARGIN
 
   let top = placeBelow ? anchor.bottom + GAP : anchor.top - height - GAP
   top = Math.max(MARGIN, Math.min(top, window.innerHeight - height - MARGIN))
@@ -133,7 +137,14 @@ const panelStyle = computed(() => {
 })
 
 watch(
-  () => [props.review.kind, props.review.status, props.review.proofread.length, props.review.variants.join('\0')] as const,
+  () => [
+    props.review.kind,
+    props.review.status,
+    props.review.proofread.length,
+    props.review.variants.join('\0'),
+    props.review.anchor?.left,
+    props.review.anchor?.right,
+  ] as const,
   async () => {
     await nextTick()
     const el = panelRef.value
@@ -161,9 +172,10 @@ function setDecision(id: string, decision: 'accept' | 'reject' | 'pending') {
   <Teleport to="body">
     <div
       ref="panelRef"
-      class="ai-review-panel fixed z-50 max-h-[min(70vh,32rem)] overflow-y-auto rounded-lg border border-default bg-elevated p-3 shadow-lg sm:p-4"
+      class="ai-review-panel fixed z-50 max-h-[min(72vh,36rem)] overflow-y-auto rounded-lg border border-default bg-elevated p-3 shadow-lg sm:p-4"
       role="dialog"
       :aria-label="title"
+      :aria-busy="isStreaming"
       :style="panelStyle"
     >
       <div class="mb-3 flex flex-wrap items-center gap-2">
@@ -179,12 +191,17 @@ function setDecision(id: string, decision: 'accept' | 'reject' | 'pending') {
           class="text-xs text-muted"
         >{{ modeLabel }}</span>
         <UBadge
-          v-if="review.status === 'streaming'"
+          v-if="isStreaming"
           color="info"
           variant="subtle"
           size="sm"
+          class="inline-flex items-center gap-1.5"
         >
-          Analyse…
+          <UIcon
+            name="i-lucide-loader-circle"
+            class="size-3.5 animate-spin"
+          />
+          Génération…
         </UBadge>
         <div class="ml-auto flex flex-wrap items-center gap-1.5">
           <UButton
@@ -211,7 +228,7 @@ function setDecision(id: string, decision: 'accept' | 'reject' | 'pending') {
             color="primary"
             variant="solid"
             icon="i-lucide-check"
-            :disabled="busy || review.status === 'streaming' || (review.kind !== 'proofread' && !activeText.trim())"
+            :disabled="busy || isStreaming || (review.kind !== 'proofread' && !activeText.trim())"
             @click="emit('accept')"
           >
             Accepter
@@ -222,19 +239,19 @@ function setDecision(id: string, decision: 'accept' | 'reject' | 'pending') {
       <!-- Reformulation: two alternatives -->
       <div
         v-if="review.kind === 'reformulate'"
-        class="mb-1 grid gap-2 sm:grid-cols-2"
+        class="grid w-full gap-3 sm:grid-cols-2"
       >
         <button
           v-for="(variant, index) in review.variants"
           :key="index"
           type="button"
-          class="rounded-md border px-3 py-2 text-left transition-colors"
+          class="min-w-0 rounded-md border px-3 py-2.5 text-left transition-colors"
           :class="index === review.activeVariant
             ? 'border-primary bg-primary/10 ring-1 ring-primary/30'
             : 'border-default bg-default hover:bg-elevated'"
           @click="setVariant(index)"
         >
-          <div class="mb-1 flex items-center justify-between gap-2">
+          <div class="mb-2 flex items-center justify-between gap-2">
             <span class="text-[11px] font-medium uppercase tracking-wide text-muted">
               Proposition {{ index + 1 }}
             </span>
@@ -247,8 +264,29 @@ function setDecision(id: string, decision: 'accept' | 'reject' | 'pending') {
               Choisie
             </UBadge>
           </div>
-          <p class="max-h-28 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-default">
-            <span class="ai-review-new-text">{{ variant || (review.status === 'streaming' ? '…' : 'Vide') }}</span>
+
+          <div
+            v-if="isStreaming && !variant.trim()"
+            class="ai-review-loading space-y-2 py-1"
+            aria-hidden="true"
+          >
+            <div class="ai-review-skeleton h-3 w-full rounded" />
+            <div class="ai-review-skeleton h-3 w-[92%] rounded" />
+            <div class="ai-review-skeleton h-3 w-[78%] rounded" />
+            <div class="ai-review-skeleton h-3 w-[88%] rounded" />
+            <p class="flex items-center gap-1.5 pt-1 text-xs text-muted">
+              <UIcon
+                name="i-lucide-loader-circle"
+                class="size-3.5 animate-spin"
+              />
+              Rédaction en cours…
+            </p>
+          </div>
+          <p
+            v-else
+            class="max-h-40 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-default"
+          >
+            <span class="ai-review-new-text">{{ variant || 'Vide' }}</span>
           </p>
         </button>
       </div>
@@ -256,22 +294,41 @@ function setDecision(id: string, decision: 'accept' | 'reject' | 'pending') {
       <!-- Continue / single proposal -->
       <div
         v-else-if="review.kind === 'continue'"
-        class="grid gap-2 sm:grid-cols-2"
+        class="grid w-full gap-3 sm:grid-cols-2"
       >
-        <div class="rounded-md border border-error/30 bg-error/5 px-3 py-2">
+        <div class="min-w-0 rounded-md border border-error/30 bg-error/5 px-3 py-2.5">
           <p class="mb-1 text-[11px] font-medium uppercase tracking-wide text-error">
             Contexte
           </p>
-          <p class="max-h-24 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-muted">
+          <p class="max-h-32 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-muted">
             {{ review.original.slice(-280) || '(début de document)' }}
           </p>
         </div>
-        <div class="rounded-md border border-success/30 bg-success/5 px-3 py-2">
+        <div class="min-w-0 rounded-md border border-success/30 bg-success/5 px-3 py-2.5">
           <p class="mb-1 text-[11px] font-medium uppercase tracking-wide text-success">
             Suite
           </p>
-          <p class="max-h-24 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-default">
-            <span class="ai-review-new-text">{{ activeText || (review.status === 'streaming' ? '…' : 'Vide') }}</span>
+          <div
+            v-if="isStreaming && !activeText.trim()"
+            class="ai-review-loading space-y-2 py-1"
+            aria-hidden="true"
+          >
+            <div class="ai-review-skeleton h-3 w-full rounded" />
+            <div class="ai-review-skeleton h-3 w-[90%] rounded" />
+            <div class="ai-review-skeleton h-3 w-[70%] rounded" />
+            <p class="flex items-center gap-1.5 pt-1 text-xs text-muted">
+              <UIcon
+                name="i-lucide-loader-circle"
+                class="size-3.5 animate-spin"
+              />
+              Rédaction en cours…
+            </p>
+          </div>
+          <p
+            v-else
+            class="max-h-32 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-default"
+          >
+            <span class="ai-review-new-text">{{ activeText || 'Vide' }}</span>
           </p>
         </div>
       </div>
@@ -279,99 +336,117 @@ function setDecision(id: string, decision: 'accept' | 'reject' | 'pending') {
       <!-- Proofread checklist -->
       <div
         v-else
-        class="space-y-3"
+        class="w-full space-y-3"
       >
-        <p class="text-xs text-muted">
-          Corrections FR-FR uniquement. Orange = suggestion · Ignorer pour laisser le texte.
-        </p>
-
-        <div class="rounded-md border border-default bg-default px-3 py-2">
-          <p class="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-muted">
-            Aperçu
-          </p>
-          <p class="text-sm leading-relaxed text-default">
-            <template
-              v-for="(part, index) in annotatedParts"
-              :key="index"
-            >
-              <span v-if="part.kind === 'text'">{{ part.text }}</span>
-              <button
-                v-else
-                type="button"
-                class="mx-0.5 inline rounded px-0.5 transition-colors"
-                :class="{
-                  'bg-warning/25 underline decoration-wavy decoration-warning': part.decision === 'pending',
-                  'bg-success/25 text-success': part.decision === 'accept',
-                  'bg-muted/30 text-muted line-through': part.decision === 'reject',
-                }"
-                :title="part.message"
-                @click="setDecision(part.id, part.decision === 'accept' ? 'pending' : 'accept')"
-              >
-                <span v-if="part.decision === 'accept'">{{ part.suggestion }}</span>
-                <span v-else>{{ part.original }}</span>
-              </button>
-            </template>
+        <div
+          v-if="isStreaming"
+          class="ai-review-loading space-y-2 rounded-md border border-default bg-default px-3 py-3"
+        >
+          <div class="ai-review-skeleton h-3 w-full rounded" />
+          <div class="ai-review-skeleton h-3 w-[85%] rounded" />
+          <div class="ai-review-skeleton h-3 w-[70%] rounded" />
+          <p class="flex items-center gap-1.5 pt-1 text-xs text-muted">
+            <UIcon
+              name="i-lucide-loader-circle"
+              class="size-3.5 animate-spin"
+            />
+            Analyse orthographique…
           </p>
         </div>
 
-        <p
-          v-if="!review.proofread.length && review.status === 'ready'"
-          class="text-sm text-muted"
-        >
-          Aucune faute détectée en français.
-        </p>
+        <template v-else>
+          <p class="text-xs text-muted">
+            Corrections FR-FR uniquement. Orange = suggestion · Ignorer pour laisser le texte.
+          </p>
 
-        <ul
-          v-else-if="review.proofread.length"
-          class="max-h-52 space-y-2 overflow-y-auto"
-        >
-          <li
-            v-for="(item, index) in review.proofread"
-            :key="item.id"
-            class="flex flex-wrap items-start gap-2 rounded-md border border-default bg-default px-3 py-2"
-            :class="{
-              'opacity-55': item.decision === 'reject',
-              'ring-1 ring-success/40': item.decision === 'accept',
-            }"
+          <div class="rounded-md border border-default bg-default px-3 py-2">
+            <p class="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-muted">
+              Aperçu
+            </p>
+            <p class="text-sm leading-relaxed text-default">
+              <template
+                v-for="(part, index) in annotatedParts"
+                :key="index"
+              >
+                <span v-if="part.kind === 'text'">{{ part.text }}</span>
+                <button
+                  v-else
+                  type="button"
+                  class="mx-0.5 inline rounded px-0.5 transition-colors"
+                  :class="{
+                    'bg-warning/25 underline decoration-wavy decoration-warning': part.decision === 'pending',
+                    'bg-success/25 text-success': part.decision === 'accept',
+                    'bg-muted/30 text-muted line-through': part.decision === 'reject',
+                  }"
+                  :title="part.message"
+                  @click="setDecision(part.id, part.decision === 'accept' ? 'pending' : 'accept')"
+                >
+                  <span v-if="part.decision === 'accept'">{{ part.suggestion }}</span>
+                  <span v-else>{{ part.original }}</span>
+                </button>
+              </template>
+            </p>
+          </div>
+
+          <p
+            v-if="!review.proofread.length && review.status === 'ready'"
+            class="text-sm text-muted"
           >
-            <span class="mt-0.5 size-5 shrink-0 rounded-full bg-elevated text-center text-[11px] font-medium leading-5 text-muted">
-              {{ index + 1 }}
-            </span>
-            <div class="min-w-0 flex-1">
-              <p class="text-sm">
-                <span class="rounded bg-warning/20 px-1 line-through decoration-warning">{{ item.original }}</span>
-                <span class="mx-1 text-muted">→</span>
-                <span class="rounded bg-success/20 px-1 font-medium text-success">{{ item.suggestion }}</span>
-              </p>
-              <p class="mt-0.5 text-xs text-muted">
-                {{ item.message }}
-              </p>
-            </div>
-            <div class="flex shrink-0 gap-1">
-              <UButton
-                size="xs"
-                color="success"
-                :variant="item.decision === 'accept' ? 'solid' : 'soft'"
-                label="Corriger"
-                @click="setDecision(item.id, item.decision === 'accept' ? 'pending' : 'accept')"
-              />
-              <UButton
-                size="xs"
-                color="neutral"
-                :variant="item.decision === 'reject' ? 'solid' : 'ghost'"
-                label="Ignorer"
-                @click="setDecision(item.id, item.decision === 'reject' ? 'pending' : 'reject')"
-              />
-            </div>
-          </li>
-        </ul>
+            Aucune faute détectée en français.
+          </p>
 
-        <p
-          v-if="review.proofread.length"
-          class="text-xs text-muted"
-        >
-          {{ applyProofreadCount }} correction(s) · {{ rejectedProofreadCount }} ignorée(s).
-        </p>
+          <ul
+            v-else-if="review.proofread.length"
+            class="max-h-52 space-y-2 overflow-y-auto"
+          >
+            <li
+              v-for="(item, index) in review.proofread"
+              :key="item.id"
+              class="flex flex-wrap items-start gap-2 rounded-md border border-default bg-default px-3 py-2"
+              :class="{
+                'opacity-55': item.decision === 'reject',
+                'ring-1 ring-success/40': item.decision === 'accept',
+              }"
+            >
+              <span class="mt-0.5 size-5 shrink-0 rounded-full bg-elevated text-center text-[11px] font-medium leading-5 text-muted">
+                {{ index + 1 }}
+              </span>
+              <div class="min-w-0 flex-1">
+                <p class="text-sm">
+                  <span class="rounded bg-warning/20 px-1 line-through decoration-warning">{{ item.original }}</span>
+                  <span class="mx-1 text-muted">→</span>
+                  <span class="rounded bg-success/20 px-1 font-medium text-success">{{ item.suggestion }}</span>
+                </p>
+                <p class="mt-0.5 text-xs text-muted">
+                  {{ item.message }}
+                </p>
+              </div>
+              <div class="flex shrink-0 gap-1">
+                <UButton
+                  size="xs"
+                  color="success"
+                  :variant="item.decision === 'accept' ? 'solid' : 'soft'"
+                  label="Corriger"
+                  @click="setDecision(item.id, item.decision === 'accept' ? 'pending' : 'accept')"
+                />
+                <UButton
+                  size="xs"
+                  color="neutral"
+                  :variant="item.decision === 'reject' ? 'solid' : 'ghost'"
+                  label="Ignorer"
+                  @click="setDecision(item.id, item.decision === 'reject' ? 'pending' : 'reject')"
+                />
+              </div>
+            </li>
+          </ul>
+
+          <p
+            v-if="review.proofread.length"
+            class="text-xs text-muted"
+          >
+            {{ applyProofreadCount }} correction(s) · {{ rejectedProofreadCount }} ignorée(s).
+          </p>
+        </template>
       </div>
     </div>
   </Teleport>

--- a/apps/cms/app/components/content/EditorAiReviewPanel.vue
+++ b/apps/cms/app/components/content/EditorAiReviewPanel.vue
@@ -166,6 +166,13 @@ function setVariant(index: number) {
 function setDecision(id: string, decision: 'accept' | 'reject' | 'pending') {
   emit('update:proofreadDecision', id, decision)
 }
+
+useFocusTrap(panelRef, { immediate: true })
+
+onKeyStroke('Escape', (event) => {
+  event.preventDefault()
+  emit('refuse')
+})
 </script>
 
 <template>
@@ -174,6 +181,7 @@ function setDecision(id: string, decision: 'accept' | 'reject' | 'pending') {
       ref="panelRef"
       class="ai-review-panel fixed z-50 max-h-[min(72vh,36rem)] overflow-y-auto rounded-lg border border-default bg-elevated p-3 shadow-lg sm:p-4"
       role="dialog"
+      aria-modal="true"
       :aria-label="title"
       :aria-busy="isStreaming"
       :style="panelStyle"

--- a/apps/cms/app/components/content/MarkdownEditor.vue
+++ b/apps/cms/app/components/content/MarkdownEditor.vue
@@ -345,7 +345,7 @@ function imageBubbleShouldShow({ editor, view }: { editor: Editor, view: { hasFo
         :handlers="editorHandlers"
         :editor-props="{
           attributes: {
-            spellcheck: 'false',
+            spellcheck: aiReview?.kind === 'proofread' ? 'false' : 'true',
           },
         }"
         :starter-kit="{

--- a/apps/cms/app/components/content/MarkdownEditor.vue
+++ b/apps/cms/app/components/content/MarkdownEditor.vue
@@ -32,8 +32,15 @@ const editorComponentRef = useTemplateRef('editorComponentRef')
 
 const {
   extension: completionExtension,
+  highlightExtension: aiHighlightExtension,
   handlers: aiHandlers,
   isLoading: aiLoading,
+  review: aiReview,
+  acceptReview,
+  refuseReview,
+  redoReview,
+  setActiveVariant,
+  setProofreadDecision,
 } = useEditorCompletion(editorComponentRef)
 
 const editorHandlers = {
@@ -336,12 +343,17 @@ function imageBubbleShouldShow({ editor, view }: { editor: Editor, view: { hasFo
         class="w-full"
         :class="embedded ? 'min-h-[20rem]' : 'min-h-[22rem]'"
         :handlers="editorHandlers"
+        :editor-props="{
+          attributes: {
+            spellcheck: 'false',
+          },
+        }"
         :starter-kit="{
           headings: { levels: [2, 3, 4] },
           link: { openOnClick: false },
         }"
         :image="false"
-        :extensions="[ContentImage, ContentCallout, ContentGridColumn, ContentGrid, completionExtension]"
+        :extensions="[ContentImage, ContentCallout, ContentGridColumn, ContentGrid, completionExtension, aiHighlightExtension]"
         :ui="{
           root: 'flex min-h-0 flex-1 flex-col',
           content: 'min-h-0 flex-1',
@@ -469,6 +481,17 @@ function imageBubbleShouldShow({ editor, view }: { editor: Editor, view: { hasFo
           :should-show="imageBubbleShouldShow"
         />
       </UEditor>
+
+      <ContentEditorAiReviewPanel
+        v-if="aiReview && !preview"
+        :review="aiReview"
+        :busy="aiLoading"
+        @accept="acceptReview"
+        @refuse="refuseReview"
+        @redo="redoReview"
+        @update:active-variant="setActiveVariant"
+        @update:proofread-decision="setProofreadDecision"
+      />
 
       <ContentEditorImageSettings
         v-model:open="imageSettingsOpen"

--- a/apps/cms/app/composables/useEditorCompletion.ts
+++ b/apps/cms/app/composables/useEditorCompletion.ts
@@ -96,6 +96,9 @@ async function streamCompletionText(options: {
 
   if (!response.body) {
     const text = await response.text()
+    if (options.signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError')
+    }
     options.onChunk(text)
     return text
   }
@@ -104,18 +107,29 @@ async function streamCompletionText(options: {
   const decoder = new TextDecoder()
   let full = ''
 
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) {
-      break
-    }
-    full += decoder.decode(value, { stream: true })
-    options.onChunk(full)
-  }
+  try {
+    while (true) {
+      if (options.signal?.aborted) {
+        await reader.cancel().catch(() => {})
+        throw new DOMException('Aborted', 'AbortError')
+      }
 
-  full += decoder.decode()
-  options.onChunk(full)
-  return full
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+      full += decoder.decode(value, { stream: true })
+      options.onChunk(full)
+    }
+
+    full += decoder.decode()
+    options.onChunk(full)
+    return full
+  }
+  catch (error) {
+    await reader.cancel().catch(() => {})
+    throw error
+  }
 }
 
 function applyProofreadDecisions(
@@ -219,11 +233,16 @@ export function useEditorCompletion(
     const endPos = Math.max(from, Math.min(to, editor.state.doc.content.size) - (to > from ? 1 : 0))
     const end = editor.view.coordsAtPos(endPos)
 
+    // Use the editor chrome width so the panel fills available horizontal space.
+    const host = editor.view.dom.closest('.cms-markdown-editor') as HTMLElement | null
+    const box = (host ?? editor.view.dom).getBoundingClientRect()
+    const pad = 8
+
     return {
       top: Math.min(start.top, end.top),
       bottom: Math.max(start.bottom, end.bottom),
-      left: Math.min(start.left, end.left),
-      right: Math.max(start.right, end.right),
+      left: box.left + pad,
+      right: box.right - pad,
     }
   }
 
@@ -237,9 +256,19 @@ export function useEditorCompletion(
     useEventListener(window, 'resize', bumpReviewAnchor)
   }
 
-  watch(session, () => {
-    bumpReviewAnchor()
-  }, { deep: true })
+  watch(
+    () => session.value
+      ? [
+          session.value.range.from,
+          session.value.range.to,
+          session.value.status,
+          session.value.kind,
+        ]
+      : null,
+    () => {
+      bumpReviewAnchor()
+    },
+  )
 
   const review = computed<AiReviewPanelModel | null>(() => {
     const current = session.value
@@ -285,17 +314,42 @@ export function useEditorCompletion(
   const isLoading = computed(() => busy.value || ghostLoading.value)
 
   function abortSession() {
-    session.value?.abort?.abort()
+    const controller = session.value?.abort
     if (session.value) {
       session.value.abort = undefined
+    }
+    // Abort after detaching so in-flight onChunk handlers no-op immediately.
+    controller?.abort()
+  }
+
+  function clearHighlightsDeferred() {
+    // Highlight teardown can be costly on large selections — keep refuse snappy.
+    const run = () => {
+      try {
+        clearHighlights()
+      }
+      catch {
+        // Editor may already be destroyed.
+      }
+    }
+    if (import.meta.client) {
+      requestAnimationFrame(run)
+    }
+    else {
+      run()
     }
   }
 
   function clearReview() {
-    abortSession()
+    // Drop the panel first so Refuser feels instant, then abort + clean decorations.
+    const controller = session.value?.abort
+    if (session.value) {
+      session.value.abort = undefined
+    }
     session.value = null
     busy.value = false
-    clearHighlights()
+    controller?.abort()
+    clearHighlightsDeferred()
   }
 
   function clearClientCompletion() {

--- a/apps/cms/app/composables/useEditorCompletion.ts
+++ b/apps/cms/app/composables/useEditorCompletion.ts
@@ -1,93 +1,279 @@
-import { useCompletion } from '@ai-sdk/vue'
 import { Extension } from '@tiptap/core'
 import type { Editor } from '@tiptap/vue-3'
+import { useCompletion } from '@ai-sdk/vue'
 import { getApiErrorMessage } from '#shared/api-error'
 import {
-  isEditorTransformMode,
   type EditorCompletionMode,
   type EditorTransformMode,
+  type ProofreadCorrection,
 } from '#shared/editor-completion-modes'
+import type { AiReviewAnchor, AiReviewKind, AiReviewPanelModel } from '~/types/editor-ai-review'
+import {
+  AiReviewHighlightExtension,
+  aiReviewHighlightUpdateMeta,
+  type AiReviewHighlightRange,
+  type AiReviewHighlightStorage,
+} from '~/utils/editor-ai-review-extension'
 import {
   EditorCompletionExtension,
   type CompletionStorage,
   completionUpdateMetaKey,
 } from '~/utils/editor-completion-extension'
+import { sanitizeProofreadCorrections } from '~/utils/editor-proofread-map'
 
 export interface UseEditorCompletionOptions {
   api?: string
+  proofreadApi?: string
 }
 
 type EditorHostRef = Ref<{ editor: Editor | undefined } | null | undefined>
+type ProofreadDecision = 'pending' | 'accept' | 'reject'
+
+interface ReviewSession {
+  kind: AiReviewKind
+  mode: EditorCompletionMode
+  language?: string
+  range: { from: number, to: number }
+  original: string
+  prompt: string
+  variants: string[]
+  activeVariant: number
+  status: 'streaming' | 'ready' | 'error'
+  proofread: Array<ProofreadCorrection & { decision: ProofreadDecision }>
+  abort?: AbortController
+}
 
 const editorCompletionServerStub = Extension.create({ name: 'completion-ssr-stub' })
 
 function createServerStub() {
   return {
     extension: editorCompletionServerStub,
+    highlightExtension: editorCompletionServerStub,
     handlers: {},
     isLoading: computed(() => false),
     mode: ref<EditorCompletionMode>('continue'),
+    review: computed(() => null as AiReviewPanelModel | null),
     stop: () => {},
+    acceptReview: () => {},
+    refuseReview: () => {},
+    redoReview: () => {},
+    setActiveVariant: (_index: number) => {},
+    setProofreadDecision: (_id: string, _decision: ProofreadDecision) => {},
   }
 }
 
+async function streamCompletionText(options: {
+  api: string
+  prompt: string
+  mode: EditorCompletionMode
+  language?: string
+  signal?: AbortSignal
+  onChunk: (text: string) => void
+}): Promise<string> {
+  const response = await fetch(options.api, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    signal: options.signal,
+    body: JSON.stringify({
+      prompt: options.prompt,
+      mode: options.mode,
+      ...(options.language ? { language: options.language } : {}),
+    }),
+  })
+
+  if (!response.ok) {
+    let message = `Erreur ${response.status}`
+    try {
+      const payload = await response.json() as { message?: string, statusMessage?: string }
+      message = payload.message || payload.statusMessage || message
+    }
+    catch {
+      // keep status message
+    }
+    throw new Error(message)
+  }
+
+  if (!response.body) {
+    const text = await response.text()
+    options.onChunk(text)
+    return text
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let full = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      break
+    }
+    full += decoder.decode(value, { stream: true })
+    options.onChunk(full)
+  }
+
+  full += decoder.decode()
+  options.onChunk(full)
+  return full
+}
+
+function applyProofreadDecisions(
+  original: string,
+  items: Array<ProofreadCorrection & { decision: ProofreadDecision }>,
+): string {
+  // Opt-out: apply pending + accepted; only Ignorer skips a suggestion.
+  const toApply = items
+    .filter(item => item.decision !== 'reject')
+    .slice()
+    .sort((a, b) => b.start - a.start)
+
+  let next = original
+  for (const item of toApply) {
+    next = `${next.slice(0, item.start)}${item.suggestion}${next.slice(item.end)}`
+  }
+  return next
+}
+
+/**
+ * AI completion for UEditor with review UX:
+ * stream → compare (old rose / new green) → Accept / Refuse / Relancer.
+ * Reformulation offers 2 variants; Orthographe lists per-error decisions.
+ */
 export function useEditorCompletion(
   editorRef: EditorHostRef,
   options: UseEditorCompletionOptions = {},
 ) {
-  // ClientOnly parent still runs this setup during SSR for the outer shell —
-  // never touch @ai-sdk/vue / toast on the server.
   if (import.meta.server) {
     return createServerStub()
   }
 
   const toast = useToast()
-  const insertState = ref<{
-    pos: number
-    deleteRange?: { from: number, to: number }
-  }>()
+  const api = options.api || '/api/completion'
+  const proofreadApi = options.proofreadApi || '/api/proofread'
+
+  const activeEditor = shallowRef<Editor | null>(null)
   const mode = ref<EditorCompletionMode>('continue')
   const language = ref<string>()
+  const session = ref<ReviewSession | null>(null)
+  const busy = ref(false)
+
+  function resolveEditor(): Editor | undefined {
+    return activeEditor.value
+      ?? editorRef.value?.editor
+      ?? undefined
+  }
 
   function getCompletionStorage() {
-    const storage = editorRef.value?.editor?.storage as Record<string, CompletionStorage> | undefined
+    const editor = resolveEditor()
+    const storage = editor?.storage as Record<string, CompletionStorage> | undefined
     return storage?.completion
   }
 
-  const { completion, complete, isLoading, stop, setCompletion } = useCompletion({
-    api: options.api || '/api/completion',
+  function getHighlightStorage() {
+    const editor = resolveEditor()
+    const storage = editor?.storage as Record<string, AiReviewHighlightStorage> | undefined
+    return storage?.aiReviewHighlight
+  }
+
+  function refreshHighlights(ranges: AiReviewHighlightRange[]) {
+    const editor = resolveEditor()
+    const storage = getHighlightStorage()
+    if (!editor || !storage) {
+      return
+    }
+    storage.setRanges(ranges)
+    editor.view.dispatch(editor.state.tr.setMeta(aiReviewHighlightUpdateMeta, true))
+  }
+
+  function clearHighlights() {
+    refreshHighlights([])
+  }
+
+  function paintSessionHighlights(current: ReviewSession) {
+    switch (current.kind) {
+      case 'continue':
+      case 'proofread':
+        // No in-doc lint underlines for orthographe — floating panel only.
+        clearHighlights()
+        return
+      case 'reformulate':
+        refreshHighlights([{ from: current.range.from, to: current.range.to, kind: 'old' }])
+        return
+      default: {
+        const _exhaustive: never = current.kind
+        return _exhaustive
+      }
+    }
+  }
+
+  function measureReviewAnchor(): AiReviewAnchor | null {
+    const editor = resolveEditor()
+    const current = session.value
+    if (!editor || !current) {
+      return null
+    }
+
+    const { from, to } = current.range
+    const start = editor.view.coordsAtPos(from)
+    const endPos = Math.max(from, Math.min(to, editor.state.doc.content.size) - (to > from ? 1 : 0))
+    const end = editor.view.coordsAtPos(endPos)
+
+    return {
+      top: Math.min(start.top, end.top),
+      bottom: Math.max(start.bottom, end.bottom),
+      left: Math.min(start.left, end.left),
+      right: Math.max(start.right, end.right),
+    }
+  }
+
+  const reviewAnchorTick = ref(0)
+  function bumpReviewAnchor() {
+    reviewAnchorTick.value += 1
+  }
+
+  if (import.meta.client) {
+    useEventListener(window, 'scroll', bumpReviewAnchor, true)
+    useEventListener(window, 'resize', bumpReviewAnchor)
+  }
+
+  watch(session, () => {
+    bumpReviewAnchor()
+  }, { deep: true })
+
+  const review = computed<AiReviewPanelModel | null>(() => {
+    const current = session.value
+    if (!current) {
+      return null
+    }
+    // Depend on tick so scroll/resize recompute coords.
+    void reviewAnchorTick.value
+    return {
+      kind: current.kind,
+      mode: current.mode,
+      original: current.original,
+      variants: current.variants,
+      activeVariant: current.activeVariant,
+      status: current.status,
+      proofread: current.proofread,
+      anchor: measureReviewAnchor(),
+    }
+  })
+
+  const {
+    completion: ghostCompletion,
+    complete: ghostComplete,
+    isLoading: ghostLoading,
+    stop: stopGhost,
+    setCompletion: setGhostCompletion,
+  } = useCompletion({
+    api,
     streamProtocol: 'text',
     credentials: 'same-origin',
-    onFinish: (_prompt, completionText) => {
-      const storage = getCompletionStorage()
-      // Ghost continue: keep suggestion until Tab / Escape.
-      if (mode.value === 'continue' && storage?.visible) {
-        return
-      }
-
-      if (isEditorTransformMode(mode.value) && insertState.value && completionText) {
-        const editor = editorRef.value?.editor
-        if (editor) {
-          if (insertState.value.deleteRange) {
-            editor.chain()
-              .focus()
-              .deleteRange(insertState.value.deleteRange)
-              .run()
-          }
-
-          editor.chain()
-            .focus()
-            .insertContentAt(insertState.value.pos, completionText, { contentType: 'markdown' })
-            .run()
-        }
-      }
-
-      insertState.value = undefined
-    },
+    body: computed(() => ({ mode: 'continue' as const })),
     onError: (error) => {
-      insertState.value = undefined
       getCompletionStorage()?.clearSuggestion()
-      setCompletion('')
+      setGhostCompletion('')
       toast.add({
         title: 'Assistance IA indisponible',
         description: getApiErrorMessage(error, 'La génération a échoué. Réessayez.'),
@@ -96,90 +282,50 @@ export function useEditorCompletion(
     },
   })
 
+  const isLoading = computed(() => busy.value || ghostLoading.value)
+
+  function abortSession() {
+    session.value?.abort?.abort()
+    if (session.value) {
+      session.value.abort = undefined
+    }
+  }
+
+  function clearReview() {
+    abortSession()
+    session.value = null
+    busy.value = false
+    clearHighlights()
+  }
+
   function clearClientCompletion() {
-    insertState.value = undefined
+    clearReview()
     getCompletionStorage()?.clearSuggestion()
-    setCompletion('')
+    setGhostCompletion('')
   }
 
   onScopeDispose(() => {
-    stop()
+    stopGhost()
     clearClientCompletion()
   })
 
-  watch(completion, (newCompletion, oldCompletion) => {
-    const editor = editorRef.value?.editor
-    if (!editor || !newCompletion) {
-      return
-    }
-
+  watch(ghostCompletion, (newCompletion) => {
+    const editor = resolveEditor()
     const storage = getCompletionStorage()
-    if (storage?.visible) {
-      let suggestionText = newCompletion
-      if (storage.position !== undefined) {
-        const textBefore = editor.state.doc.textBetween(Math.max(0, storage.position - 1), storage.position)
-        if (textBefore && !/\s/.test(textBefore) && !suggestionText.startsWith(' ')) {
-          suggestionText = ` ${suggestionText}`
-        }
+    if (!editor || !storage?.visible || !newCompletion) {
+      return
+    }
+
+    let suggestionText = newCompletion
+    if (storage.position !== undefined) {
+      const textBefore = editor.state.doc.textBetween(Math.max(0, storage.position - 1), storage.position)
+      if (textBefore && !/\s/.test(textBefore) && !suggestionText.startsWith(' ')) {
+        suggestionText = ` ${suggestionText}`
       }
-      storage.setSuggestion(suggestionText)
-      editor.view.dispatch(editor.state.tr.setMeta(completionUpdateMetaKey, true))
-      return
     }
-
-    // Transform modes wait for onFinish (markdown insert). Do not stream into the doc.
-    if (isEditorTransformMode(mode.value) || !insertState.value) {
-      return
-    }
-
-    if (insertState.value.deleteRange && !oldCompletion) {
-      editor.chain()
-        .focus()
-        .deleteRange(insertState.value.deleteRange)
-        .run()
-      insertState.value.deleteRange = undefined
-    }
-
-    const delta = newCompletion.slice(oldCompletion?.length || 0)
-    if (!delta) {
-      return
-    }
-
-    editor.chain().focus().command(({ tr }) => {
-      tr.insertText(delta, insertState.value!.pos)
-      return true
-    }).run()
-    insertState.value.pos += delta.length
+    storage.setSuggestion(suggestionText)
+    editor.view.dispatch(editor.state.tr.setMeta(completionUpdateMetaKey, true))
   })
-
-  function requestBody() {
-    return {
-      mode: mode.value,
-      language: language.value,
-    }
-  }
-
-  function triggerTransform(editor: Editor, transformMode: EditorTransformMode, lang?: string) {
-    if (isLoading.value) {
-      return
-    }
-
-    getCompletionStorage()?.clearSuggestion()
-
-    const { state } = editor
-    const { selection } = state
-
-    if (selection.empty) {
-      return
-    }
-
-    mode.value = transformMode
-    language.value = lang
-    const selectedText = state.doc.textBetween(selection.from, selection.to)
-
-    insertState.value = { pos: selection.from, deleteRange: { from: selection.from, to: selection.to } }
-    void complete(selectedText, { body: requestBody() })
-  }
 
   function getMarkdownBefore(editor: Editor, pos: number): string {
     const { state } = editor
@@ -191,45 +337,392 @@ export function useEditorCompletion(
     return state.doc.textBetween(0, pos, '\n')
   }
 
-  /** Ghost-text continue (toolbar + Mod-j share this path). */
+  async function runContinueSession(current: ReviewSession) {
+    busy.value = true
+    current.status = 'streaming'
+    current.variants = ['']
+    current.activeVariant = 0
+    const abort = new AbortController()
+    current.abort = abort
+    session.value = { ...current }
+
+    try {
+      await streamCompletionText({
+        api,
+        prompt: current.prompt,
+        mode: 'continue',
+        signal: abort.signal,
+        onChunk: (text) => {
+          if (!session.value || session.value.abort !== abort) {
+            return
+          }
+          session.value = {
+            ...session.value,
+            variants: [text],
+            status: 'streaming',
+          }
+        },
+      })
+      if (session.value?.abort === abort) {
+        session.value = {
+          ...session.value,
+          status: session.value.variants[0]?.trim() ? 'ready' : 'error',
+        }
+      }
+    }
+    catch (error) {
+      if (abort.signal.aborted) {
+        return
+      }
+      toast.add({
+        title: 'Assistance IA',
+        description: getApiErrorMessage(error, 'La génération a échoué.'),
+        color: 'error',
+      })
+      if (session.value?.abort === abort) {
+        session.value = { ...session.value, status: 'error' }
+      }
+    }
+    finally {
+      if (session.value?.abort === abort) {
+        busy.value = false
+      }
+    }
+  }
+
+  async function runReformulateSession(current: ReviewSession) {
+    busy.value = true
+    current.status = 'streaming'
+    current.variants = ['', '']
+    current.activeVariant = 0
+    const abort = new AbortController()
+    current.abort = abort
+    session.value = { ...current }
+    paintSessionHighlights(current)
+
+    try {
+      await Promise.all([0, 1].map(async (index) => {
+        await streamCompletionText({
+          api,
+          prompt: current.prompt,
+          mode: current.mode,
+          language: current.language,
+          signal: abort.signal,
+          onChunk: (text) => {
+            if (!session.value || session.value.abort !== abort) {
+              return
+            }
+            const variants = [...session.value.variants]
+            variants[index] = text
+            session.value = {
+              ...session.value,
+              variants,
+              status: 'streaming',
+            }
+          },
+        })
+      }))
+
+      if (session.value?.abort === abort) {
+        const hasText = session.value.variants.some(v => v.trim())
+        session.value = {
+          ...session.value,
+          status: hasText ? 'ready' : 'error',
+        }
+      }
+    }
+    catch (error) {
+      if (abort.signal.aborted) {
+        return
+      }
+      toast.add({
+        title: 'Assistance IA',
+        description: getApiErrorMessage(error, 'La génération a échoué.'),
+        color: 'error',
+      })
+      if (session.value?.abort === abort) {
+        session.value = { ...session.value, status: 'error' }
+      }
+    }
+    finally {
+      if (session.value?.abort === abort) {
+        busy.value = false
+      }
+    }
+  }
+
+  async function runProofreadSession(current: ReviewSession) {
+    busy.value = true
+    current.status = 'streaming'
+    current.proofread = []
+    const abort = new AbortController()
+    current.abort = abort
+    session.value = { ...current }
+    paintSessionHighlights(current)
+
+    try {
+      const payload = await $fetch<{ corrections: ProofreadCorrection[] }>(proofreadApi, {
+        method: 'POST',
+        body: { text: current.original },
+        signal: abort.signal,
+      })
+
+      if (session.value?.abort !== abort) {
+        return
+      }
+
+      const proofread = sanitizeProofreadCorrections(
+        current.original,
+        payload.corrections || [],
+      ).map(item => ({
+        ...item,
+        decision: 'pending' as const,
+      }))
+
+      if (!proofread.length) {
+        toast.add({
+          title: 'Orthographe',
+          description: 'Aucune faute détectée en français.',
+          color: 'success',
+        })
+        busy.value = false
+        clearReview()
+        return
+      }
+
+      session.value = {
+        ...session.value,
+        proofread,
+        status: 'ready',
+        variants: [],
+      }
+      paintSessionHighlights(session.value)
+    }
+    catch (error) {
+      if (abort.signal.aborted) {
+        return
+      }
+      toast.add({
+        title: 'Orthographe',
+        description: getApiErrorMessage(error, 'L’analyse a échoué.'),
+        color: 'error',
+      })
+      if (session.value?.abort === abort) {
+        session.value = { ...session.value, status: 'error' }
+      }
+    }
+    finally {
+      if (session.value?.abort === abort) {
+        busy.value = false
+      }
+    }
+  }
+
+  function startReviewSession(next: Omit<ReviewSession, 'variants' | 'activeVariant' | 'status' | 'proofread' | 'abort'> & {
+    kind: AiReviewKind
+  }) {
+    abortSession()
+    getCompletionStorage()?.clearSuggestion()
+    setGhostCompletion('')
+
+    const base: ReviewSession = {
+      ...next,
+      variants: next.kind === 'reformulate' ? ['', ''] : [''],
+      activeVariant: 0,
+      status: 'streaming',
+      proofread: [],
+    }
+
+    mode.value = next.mode
+    language.value = next.language
+    session.value = base
+
+    if (next.kind === 'continue') {
+      void runContinueSession(base)
+      return
+    }
+    if (next.kind === 'proofread') {
+      void runProofreadSession(base)
+      return
+    }
+    void runReformulateSession(base)
+  }
+
   function triggerContinue(editor: Editor) {
     if (isLoading.value) {
       return
     }
-
-    mode.value = 'continue'
-    language.value = undefined
-    insertState.value = undefined
-
-    const storage = getCompletionStorage()
-    storage?.clearSuggestion()
-
+    activeEditor.value = editor
     const { selection } = editor.state
-    const pos = selection.empty ? selection.from : selection.to
+    let pos = selection.empty ? selection.from : selection.to
+    // Toolbar click often leaves the caret at doc start — continue from end of content.
+    if (pos <= 1 || !getMarkdownBefore(editor, pos).trim()) {
+      pos = Math.max(1, editor.state.doc.content.size - 1)
+    }
+    const prompt = getMarkdownBefore(editor, pos)
+    startReviewSession({
+      kind: 'continue',
+      mode: 'continue',
+      range: { from: pos, to: pos },
+      original: prompt,
+      prompt,
+    })
+  }
 
-    if (storage) {
-      storage.position = pos
-      storage.visible = true
+  function triggerTransform(editor: Editor, transformMode: EditorTransformMode, lang?: string) {
+    if (isLoading.value) {
+      return
     }
 
-    void complete(getMarkdownBefore(editor, pos), { body: requestBody() })
+    activeEditor.value = editor
+    const { selection } = editor.state
+    if (selection.empty) {
+      return
+    }
+
+    const selectedText = stateTextBetween(editor, selection.from, selection.to)
+
+    if (transformMode === 'fix') {
+      startReviewSession({
+        kind: 'proofread',
+        mode: 'fix',
+        range: { from: selection.from, to: selection.to },
+        original: selectedText,
+        prompt: selectedText,
+      })
+      return
+    }
+
+    startReviewSession({
+      kind: 'reformulate',
+      mode: transformMode,
+      language: lang,
+      range: { from: selection.from, to: selection.to },
+      original: selectedText,
+      prompt: selectedText,
+    })
+  }
+
+  function stateTextBetween(editor: Editor, from: number, to: number) {
+    return editor.state.doc.textBetween(from, to, '\n')
+  }
+
+  function acceptReview() {
+    const current = session.value
+    const editor = resolveEditor()
+    if (!current || !editor || current.status === 'streaming') {
+      return
+    }
+
+    if (current.kind === 'continue') {
+      const text = current.variants[0]?.trim()
+      if (!text) {
+        return
+      }
+      let insert = text
+      const textBefore = editor.state.doc.textBetween(
+        Math.max(0, current.range.from - 1),
+        current.range.from,
+      )
+      if (textBefore && !/\s/.test(textBefore) && !insert.startsWith(' ')) {
+        insert = ` ${insert}`
+      }
+      editor.chain().focus().insertContentAt(current.range.from, insert).run()
+      clearReview()
+      return
+    }
+
+    if (current.kind === 'reformulate') {
+      const text = current.variants[current.activeVariant]?.trim()
+      if (!text) {
+        return
+      }
+      editor.chain()
+        .focus()
+        .deleteRange({ from: current.range.from, to: current.range.to })
+        .insertContentAt(current.range.from, text, { contentType: 'markdown' })
+        .run()
+      clearReview()
+      return
+    }
+
+    const nextText = applyProofreadDecisions(current.original, current.proofread)
+    if (nextText === current.original) {
+      // Nothing to apply (no errors, or all ignored) — just close the review.
+      clearReview()
+      return
+    }
+
+    editor.chain()
+      .focus()
+      .deleteRange({ from: current.range.from, to: current.range.to })
+      .insertContentAt(current.range.from, nextText)
+      .run()
+    clearReview()
+  }
+
+  function refuseReview() {
+    clearReview()
+  }
+
+  function redoReview() {
+    const current = session.value
+    if (!current || busy.value) {
+      return
+    }
+    startReviewSession({
+      kind: current.kind,
+      mode: current.mode,
+      language: current.language,
+      range: current.range,
+      original: current.original,
+      prompt: current.prompt,
+    })
+  }
+
+  function setActiveVariant(index: number) {
+    if (!session.value || index < 0 || index >= session.value.variants.length) {
+      return
+    }
+    session.value = { ...session.value, activeVariant: index }
+  }
+
+  function setProofreadDecision(id: string, decision: ProofreadDecision) {
+    if (!session.value) {
+      return
+    }
+    session.value = {
+      ...session.value,
+      proofread: session.value.proofread.map(item =>
+        item.id === id ? { ...item, decision } : item,
+      ),
+    }
+    paintSessionHighlights(session.value)
   }
 
   const extension = EditorCompletionExtension.configure({
     onTrigger: (editor) => {
-      if (isLoading.value) {
+      if (isLoading.value || session.value) {
         return
       }
-      triggerContinue(editor)
+      activeEditor.value = editor
+      mode.value = 'continue'
+      language.value = undefined
+      void ghostComplete(getMarkdownBefore(editor, editor.state.selection.from))
     },
     onAccept: () => {
-      setCompletion('')
+      setGhostCompletion('')
     },
     onDismiss: () => {
-      stop()
-      setCompletion('')
+      if (session.value) {
+        return
+      }
+      stopGhost()
+      setGhostCompletion('')
     },
   })
+
+  const highlightExtension = AiReviewHighlightExtension
 
   const handlers = {
     aiContinue: {
@@ -300,9 +793,20 @@ export function useEditorCompletion(
 
   return {
     extension,
+    highlightExtension,
     handlers,
     isLoading,
     mode,
-    stop,
+    review,
+    stop: () => {
+      stopGhost()
+      abortSession()
+      busy.value = false
+    },
+    acceptReview,
+    refuseReview,
+    redoReview,
+    setActiveVariant,
+    setProofreadDecision,
   }
 }

--- a/apps/cms/app/composables/useEditorCompletion.ts
+++ b/apps/cms/app/composables/useEditorCompletion.ts
@@ -1,4 +1,5 @@
 import { Extension } from '@tiptap/core'
+import type { JSONContent } from '@tiptap/core'
 import type { Editor } from '@tiptap/vue-3'
 import { useCompletion } from '@ai-sdk/vue'
 import { getApiErrorMessage } from '#shared/api-error'
@@ -147,6 +148,14 @@ function applyProofreadDecisions(
     next = `${next.slice(0, item.start)}${item.suggestion}${next.slice(item.end)}`
   }
   return next
+}
+
+/** Insert plain review text without markdown parsing (`*`, `_`, `#` stay literal). */
+function plainReviewTextToDocContent(text: string): JSONContent[] {
+  return text.split('\n').map(line => ({
+    type: 'paragraph',
+    content: line ? [{ type: 'text', text: line }] : [],
+  }))
 }
 
 /**
@@ -754,7 +763,7 @@ export function useEditorCompletion(
     editor.chain()
       .focus()
       .deleteRange({ from: current.range.from, to: current.range.to })
-      .insertContentAt(current.range.from, nextText, { contentType: 'markdown' })
+      .insertContentAt(current.range.from, plainReviewTextToDocContent(nextText))
       .run()
     clearReview()
   }

--- a/apps/cms/app/composables/useEditorCompletion.ts
+++ b/apps/cms/app/composables/useEditorCompletion.ts
@@ -228,21 +228,30 @@ export function useEditorCompletion(
       return null
     }
 
-    const { from, to } = current.range
-    const start = editor.view.coordsAtPos(from)
-    const endPos = Math.max(from, Math.min(to, editor.state.doc.content.size) - (to > from ? 1 : 0))
-    const end = editor.view.coordsAtPos(endPos)
+    try {
+      const docSize = editor.state.doc.content.size
+      const { from, to } = current.range
+      const safeFrom = Math.max(0, Math.min(from, docSize))
+      const endPos = Math.max(
+        safeFrom,
+        Math.min(to, docSize) - (to > safeFrom ? 1 : 0),
+      )
+      const start = editor.view.coordsAtPos(safeFrom)
+      const end = editor.view.coordsAtPos(endPos)
 
-    // Use the editor chrome width so the panel fills available horizontal space.
-    const host = editor.view.dom.closest('.cms-markdown-editor') as HTMLElement | null
-    const box = (host ?? editor.view.dom).getBoundingClientRect()
-    const pad = 8
+      const host = editor.view.dom.closest('.cms-markdown-editor') as HTMLElement | null
+      const box = (host ?? editor.view.dom).getBoundingClientRect()
+      const pad = 8
 
-    return {
-      top: Math.min(start.top, end.top),
-      bottom: Math.max(start.bottom, end.bottom),
-      left: box.left + pad,
-      right: box.right - pad,
+      return {
+        top: Math.min(start.top, end.top),
+        bottom: Math.max(start.bottom, end.bottom),
+        left: box.left + pad,
+        right: box.right - pad,
+      }
+    }
+    catch {
+      return null
     }
   }
 
@@ -454,6 +463,8 @@ export function useEditorCompletion(
     session.value = { ...current }
     paintSessionHighlights(current)
 
+    const variantBuffers = ['', '']
+
     try {
       await Promise.all([0, 1].map(async (index) => {
         await streamCompletionText({
@@ -466,11 +477,10 @@ export function useEditorCompletion(
             if (!session.value || session.value.abort !== abort) {
               return
             }
-            const variants = [...session.value.variants]
-            variants[index] = text
+            variantBuffers[index] = text
             session.value = {
               ...session.value,
-              variants,
+              variants: [...variantBuffers],
               status: 'streaming',
             }
           },
@@ -661,6 +671,14 @@ export function useEditorCompletion(
     return editor.state.doc.textBetween(from, to, '\n')
   }
 
+  function reviewRangeStillValid(editor: Editor, from: number, to: number, expected: string): boolean {
+    const docSize = editor.state.doc.content.size
+    if (from < 0 || to > docSize || from > to) {
+      return false
+    }
+    return stateTextBetween(editor, from, to) === expected
+  }
+
   function acceptReview() {
     const current = session.value
     const editor = resolveEditor()
@@ -671,6 +689,15 @@ export function useEditorCompletion(
     if (current.kind === 'continue') {
       const text = current.variants[0]?.trim()
       if (!text) {
+        return
+      }
+      const docSize = editor.state.doc.content.size
+      if (current.range.from < 0 || current.range.from > docSize) {
+        toast.add({
+          title: 'Assistance IA',
+          description: 'Le document a changé. Relancez la génération.',
+          color: 'warning',
+        })
         return
       }
       let insert = text
@@ -691,6 +718,14 @@ export function useEditorCompletion(
       if (!text) {
         return
       }
+      if (!reviewRangeStillValid(editor, current.range.from, current.range.to, current.original)) {
+        toast.add({
+          title: 'Assistance IA',
+          description: 'La sélection a changé. Relancez la reformulation.',
+          color: 'warning',
+        })
+        return
+      }
       editor.chain()
         .focus()
         .deleteRange({ from: current.range.from, to: current.range.to })
@@ -707,10 +742,19 @@ export function useEditorCompletion(
       return
     }
 
+    if (!reviewRangeStillValid(editor, current.range.from, current.range.to, current.original)) {
+      toast.add({
+        title: 'Orthographe',
+        description: 'La sélection a changé. Relancez l’analyse.',
+        color: 'warning',
+      })
+      return
+    }
+
     editor.chain()
       .focus()
       .deleteRange({ from: current.range.from, to: current.range.to })
-      .insertContentAt(current.range.from, nextText)
+      .insertContentAt(current.range.from, nextText, { contentType: 'markdown' })
       .run()
     clearReview()
   }
@@ -757,12 +801,13 @@ export function useEditorCompletion(
   const extension = EditorCompletionExtension.configure({
     onTrigger: (editor) => {
       if (isLoading.value || session.value) {
-        return
+        return false
       }
       activeEditor.value = editor
       mode.value = 'continue'
       language.value = undefined
       void ghostComplete(getMarkdownBefore(editor, editor.state.selection.from))
+      return true
     },
     onAccept: () => {
       setGhostCompletion('')

--- a/apps/cms/app/composables/useEditorCompletion.ts
+++ b/apps/cms/app/composables/useEditorCompletion.ts
@@ -709,6 +709,15 @@ export function useEditorCompletion(
         })
         return
       }
+      const promptNow = getMarkdownBefore(editor, current.range.from)
+      if (promptNow !== current.prompt) {
+        toast.add({
+          title: 'Assistance IA',
+          description: 'Le document a changé. Relancez la génération.',
+          color: 'warning',
+        })
+        return
+      }
       let insert = text
       const textBefore = editor.state.doc.textBetween(
         Math.max(0, current.range.from - 1),
@@ -763,7 +772,12 @@ export function useEditorCompletion(
     editor.chain()
       .focus()
       .deleteRange({ from: current.range.from, to: current.range.to })
-      .insertContentAt(current.range.from, plainReviewTextToDocContent(nextText))
+      .insertContentAt(
+        current.range.from,
+        nextText.includes('\n')
+          ? plainReviewTextToDocContent(nextText)
+          : [{ type: 'text', text: nextText }],
+      )
       .run()
     clearReview()
   }

--- a/apps/cms/app/types/editor-ai-review.ts
+++ b/apps/cms/app/types/editor-ai-review.ts
@@ -1,0 +1,22 @@
+import type { EditorCompletionMode, ProofreadCorrection } from '#shared/editor-completion-modes'
+
+export type AiReviewKind = 'continue' | 'reformulate' | 'proofread'
+
+export interface AiReviewAnchor {
+  top: number
+  bottom: number
+  left: number
+  right: number
+}
+
+export interface AiReviewPanelModel {
+  kind: AiReviewKind
+  mode: EditorCompletionMode
+  original: string
+  variants: string[]
+  activeVariant: number
+  status: 'streaming' | 'ready' | 'error'
+  proofread: Array<ProofreadCorrection & { decision: 'pending' | 'accept' | 'reject' }>
+  /** Viewport coords of the selection used as popover anchor. */
+  anchor: AiReviewAnchor | null
+}

--- a/apps/cms/app/utils/editor-ai-review-extension.ts
+++ b/apps/cms/app/utils/editor-ai-review-extension.ts
@@ -53,7 +53,21 @@ export const AiReviewHighlightExtension = Extension.create<
             return 0
           },
           apply(tr, tick) {
-            if (tr.getMeta(aiReviewHighlightUpdateMeta)) {
+            if (tr.docChanged && storage.ranges.length) {
+              const docSize = tr.doc.content.size
+              storage.ranges = storage.ranges
+                .map((range) => {
+                  const from = tr.mapping.map(range.from, -1)
+                  const to = tr.mapping.map(range.to, 1)
+                  return { ...range, from, to }
+                })
+                .filter(range =>
+                  range.to > range.from
+                  && range.from >= 0
+                  && range.to <= docSize,
+                )
+            }
+            if (tr.getMeta(aiReviewHighlightUpdateMeta) || tr.docChanged) {
               return tick + 1
             }
             return tick
@@ -66,7 +80,7 @@ export const AiReviewHighlightExtension = Extension.create<
             }
 
             const decorations = storage.ranges
-              .filter(range => range.to > range.from)
+              .filter(range => range.to > range.from && range.from >= 0 && range.to <= state.doc.content.size)
               .map((range) => {
                 const className = range.kind === 'old'
                   ? 'ai-review-old'

--- a/apps/cms/app/utils/editor-ai-review-extension.ts
+++ b/apps/cms/app/utils/editor-ai-review-extension.ts
@@ -1,0 +1,86 @@
+import { Extension } from '@tiptap/core'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+
+export interface AiReviewHighlightRange {
+  from: number
+  to: number
+  /** `old` = original selection (rose), `error` = proofread span (amber/rose). */
+  kind: 'old' | 'error'
+  /** Optional correction id for proofread spans. */
+  id?: string
+}
+
+export interface AiReviewHighlightStorage {
+  ranges: AiReviewHighlightRange[]
+  setRanges: (ranges: AiReviewHighlightRange[]) => void
+  clear: () => void
+}
+
+export const aiReviewHighlightPluginKey = new PluginKey('aiReviewHighlight')
+export const aiReviewHighlightUpdateMeta = 'aiReviewHighlightUpdate'
+
+/**
+ * Inline decorations for AI review: original text (rose) and per-error spans.
+ * Proposed text lives in the review panel (green), not as an in-doc duplicate.
+ */
+export const AiReviewHighlightExtension = Extension.create<
+  Record<string, never>,
+  AiReviewHighlightStorage
+>({
+  name: 'aiReviewHighlight',
+
+  addStorage() {
+    return {
+      ranges: [] as AiReviewHighlightRange[],
+      setRanges(ranges: AiReviewHighlightRange[]) {
+        this.ranges = ranges
+      },
+      clear() {
+        this.ranges = []
+      },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    const storage = this.storage
+
+    return [
+      new Plugin({
+        key: aiReviewHighlightPluginKey,
+        state: {
+          init() {
+            return 0
+          },
+          apply(tr, tick) {
+            if (tr.getMeta(aiReviewHighlightUpdateMeta)) {
+              return tick + 1
+            }
+            return tick
+          },
+        },
+        props: {
+          decorations(state) {
+            if (!storage.ranges.length) {
+              return DecorationSet.empty
+            }
+
+            const decorations = storage.ranges
+              .filter(range => range.to > range.from)
+              .map((range) => {
+                const className = range.kind === 'old'
+                  ? 'ai-review-old'
+                  : 'ai-review-error'
+                return Decoration.inline(range.from, range.to, {
+                  class: className,
+                  ...(range.id ? { 'data-ai-correction-id': range.id } : {}),
+                })
+              })
+
+            return DecorationSet.create(state.doc, decorations)
+          },
+        },
+      }),
+    ]
+  },
+})

--- a/apps/cms/app/utils/editor-completion-extension.ts
+++ b/apps/cms/app/utils/editor-completion-extension.ts
@@ -32,7 +32,7 @@ export interface CompletionOptions {
   debounce?: number
   autoTrigger?: boolean
   triggerCharacters?: string[]
-  onTrigger?: (editor: Editor) => void
+  onTrigger?: (editor: Editor) => boolean | void
   onAccept?: () => void
   onDismiss?: () => void
 }
@@ -126,11 +126,14 @@ export const EditorCompletionExtension = Extension.create<CompletionOptions, Com
           this.storage.clearSuggestion()
           this.options.onDismiss?.()
         }
-        // Manual invoke: skip auto-trigger guards (punctuation / end-of-block).
         const { selection } = editor.state
         this.storage.position = selection.from
+        const triggered = this.options.onTrigger?.(editor as Editor)
+        if (triggered === false) {
+          this.storage.position = undefined
+          return true
+        }
         this.storage.visible = true
-        this.options.onTrigger?.(editor as Editor)
         return true
       },
       Tab: ({ editor }) => {
@@ -207,8 +210,12 @@ export const EditorCompletionExtension = Extension.create<CompletionOptions, Com
       }
 
       storage.position = selection.from
+      const triggered = options.onTrigger(editor)
+      if (triggered === false) {
+        storage.position = undefined
+        return
+      }
       storage.visible = true
-      options.onTrigger(editor)
     }, options.debounce || 250)
   },
 

--- a/apps/cms/app/utils/editor-completion-extension.ts
+++ b/apps/cms/app/utils/editor-completion-extension.ts
@@ -107,6 +107,8 @@ export const EditorCompletionExtension = Extension.create<CompletionOptions, Com
               const span = document.createElement('span')
               span.className = 'completion-suggestion'
               span.textContent = storage.suggestion
+              // Match nuxt-ui-templates/editor ghost styling (no project CSS required).
+              span.style.cssText = 'color: var(--ui-text-muted); opacity: 0.6; pointer-events: none;'
               return span
             }, { side: 1 })
 
@@ -158,6 +160,8 @@ export const EditorCompletionExtension = Extension.create<CompletionOptions, Com
   },
 
   onUpdate({ editor }) {
+    // Only dismiss ghost suggestions — toolbar Continuer streams via insertState
+    // and must not be aborted when the bubble menu closes.
     if (this.storage.visible) {
       this.storage.clearSuggestion()
       editor.view.dispatch(editor.state.tr.setMeta(completionUpdateMetaKey, true))

--- a/apps/cms/app/utils/editor-proofread-map.ts
+++ b/apps/cms/app/utils/editor-proofread-map.ts
@@ -1,6 +1,6 @@
 import type { Node as PmNode } from '@tiptap/pm/model'
-import type { ProofreadCorrection } from '../../shared/editor-completion-modes'
-import { isPlausibleSpellingFix } from '../../shared/proofread-sanitize'
+import type { ProofreadCorrection } from '#shared/editor-completion-modes'
+import { isPlausibleSpellingFix } from '#shared/proofread-sanitize'
 
 const MAX_CORRECTION_CHARS = 48
 

--- a/apps/cms/app/utils/editor-proofread-map.ts
+++ b/apps/cms/app/utils/editor-proofread-map.ts
@@ -1,6 +1,6 @@
 import type { Node as PmNode } from '@tiptap/pm/model'
 import type { ProofreadCorrection } from '#shared/editor-completion-modes'
-import { isPlausibleSpellingFix, proofreadMaxSpanChars } from '../../shared/proofread-sanitize'
+import { isPlausibleSpellingFix, proofreadMaxSpanChars } from '#shared/proofread-sanitize'
 
 /**
  * Map a UTF-16 offset inside `doc.textBetween(rangeFrom, rangeTo, blockSeparator)`

--- a/apps/cms/app/utils/editor-proofread-map.ts
+++ b/apps/cms/app/utils/editor-proofread-map.ts
@@ -1,0 +1,131 @@
+import type { Node as PmNode } from '@tiptap/pm/model'
+import type { ProofreadCorrection } from '../../shared/editor-completion-modes'
+import { isPlausibleSpellingFix } from '../../shared/proofread-sanitize'
+
+const MAX_CORRECTION_CHARS = 48
+
+/**
+ * Map a UTF-16 offset inside `doc.textBetween(rangeFrom, rangeTo, blockSeparator)`
+ * back to a ProseMirror document position.
+ */
+export function plainOffsetToDocPos(
+  doc: PmNode,
+  rangeFrom: number,
+  rangeTo: number,
+  plainOffset: number,
+  blockSeparator = '\n',
+): number {
+  if (plainOffset <= 0) {
+    return rangeFrom
+  }
+
+  let remaining = plainOffset
+  let mapped = rangeFrom
+  let seenText = false
+  let lastTextParent: PmNode | null = null
+
+  doc.nodesBetween(rangeFrom, rangeTo, (node, pos, parent) => {
+    if (!node.isText || !parent) {
+      return
+    }
+
+    if (seenText && parent !== lastTextParent && blockSeparator) {
+      if (remaining <= blockSeparator.length) {
+        mapped = Math.max(pos, rangeFrom)
+        return false
+      }
+      remaining -= blockSeparator.length
+    }
+
+    lastTextParent = parent
+    seenText = true
+
+    const from = Math.max(pos, rangeFrom)
+    const to = Math.min(pos + node.nodeSize, rangeTo)
+    const len = to - from
+    if (len <= 0) {
+      return
+    }
+
+    if (remaining <= len) {
+      mapped = from + remaining
+      return false
+    }
+
+    remaining -= len
+  })
+
+  return mapped
+}
+
+export function proofreadRangesInDoc(
+  doc: PmNode,
+  rangeFrom: number,
+  rangeTo: number,
+  corrections: Array<Pick<ProofreadCorrection, 'id' | 'start' | 'end' | 'original'>>,
+  blockSeparator = '\n',
+): Array<{ from: number, to: number, id: string }> {
+  return corrections.flatMap((item) => {
+    const from = plainOffsetToDocPos(doc, rangeFrom, rangeTo, item.start, blockSeparator)
+    const to = plainOffsetToDocPos(doc, rangeFrom, rangeTo, item.end, blockSeparator)
+    if (to <= from || from < rangeFrom || to > rangeTo) {
+      return []
+    }
+    // Guard against bad offsets painting unrelated words outside the error.
+    const slice = doc.textBetween(from, to, blockSeparator)
+    if (item.original && slice !== item.original) {
+      return []
+    }
+    return [{ from, to, id: item.id }]
+  })
+}
+
+/**
+ * Drop no-ops, duplicates, rewrites, and spans that cover almost the whole selection
+ * (those paint random words and confuse authors).
+ */
+export function sanitizeProofreadCorrections(
+  text: string,
+  corrections: ProofreadCorrection[],
+): ProofreadCorrection[] {
+  const maxSpan = Math.min(MAX_CORRECTION_CHARS, Math.max(12, Math.floor(text.length * 0.35)))
+  const seen = new Set<string>()
+  const out: ProofreadCorrection[] = []
+
+  for (const item of corrections) {
+    if (!isPlausibleSpellingFix(item.original, item.suggestion)) {
+      continue
+    }
+    if (item.end <= item.start) {
+      continue
+    }
+    const span = item.end - item.start
+    if (span > maxSpan) {
+      continue
+    }
+    if (text.slice(item.start, item.end) !== item.original) {
+      continue
+    }
+
+    const key = `${item.start}:${item.end}:${item.suggestion}`
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    out.push(item)
+  }
+
+  // Prefer non-overlapping: keep earlier shorter spans first.
+  out.sort((a, b) => a.start - b.start || (a.end - a.start) - (b.end - b.start))
+  const nonOverlap: ProofreadCorrection[] = []
+  let cursor = 0
+  for (const item of out) {
+    if (item.start < cursor) {
+      continue
+    }
+    nonOverlap.push(item)
+    cursor = item.end
+  }
+
+  return nonOverlap
+}

--- a/apps/cms/app/utils/editor-proofread-map.ts
+++ b/apps/cms/app/utils/editor-proofread-map.ts
@@ -1,8 +1,6 @@
 import type { Node as PmNode } from '@tiptap/pm/model'
 import type { ProofreadCorrection } from '#shared/editor-completion-modes'
-import { isPlausibleSpellingFix } from '#shared/proofread-sanitize'
-
-const MAX_CORRECTION_CHARS = 48
+import { isPlausibleSpellingFix, proofreadMaxSpanChars } from '../../shared/proofread-sanitize'
 
 /**
  * Map a UTF-16 offset inside `doc.textBetween(rangeFrom, rangeTo, blockSeparator)`
@@ -23,8 +21,12 @@ export function plainOffsetToDocPos(
   let mapped = rangeFrom
   let seenText = false
   let lastTextParent: PmNode | null = null
+  let done = false
 
   doc.nodesBetween(rangeFrom, rangeTo, (node, pos, parent) => {
+    if (done) {
+      return false
+    }
     if (!node.isText || !parent) {
       return
     }
@@ -32,6 +34,7 @@ export function plainOffsetToDocPos(
     if (seenText && parent !== lastTextParent && blockSeparator) {
       if (remaining <= blockSeparator.length) {
         mapped = Math.max(pos, rangeFrom)
+        done = true
         return false
       }
       remaining -= blockSeparator.length
@@ -49,6 +52,7 @@ export function plainOffsetToDocPos(
 
     if (remaining <= len) {
       mapped = from + remaining
+      done = true
       return false
     }
 
@@ -88,7 +92,7 @@ export function sanitizeProofreadCorrections(
   text: string,
   corrections: ProofreadCorrection[],
 ): ProofreadCorrection[] {
-  const maxSpan = Math.min(MAX_CORRECTION_CHARS, Math.max(12, Math.floor(text.length * 0.35)))
+  const maxSpan = proofreadMaxSpanChars(text.length)
   const seen = new Set<string>()
   const out: ProofreadCorrection[] = []
 

--- a/apps/cms/nuxt.config.ts
+++ b/apps/cms/nuxt.config.ts
@@ -16,12 +16,12 @@ function writeDevWranglerConfig(nitroConfig: {
   // to avoid Wrangler’s noisy “not available in local development” warning.
   delete wrangler.workflows
   const devWrangler = {
+    ...wrangler,
     name: 'jdc-cms-local',
     compatibility_date:
       nitroConfig.compatibilityDate?.cloudflare
       ?? nitroConfig.compatibilityDate?.default
       ?? '2026-05-27',
-    ...wrangler,
   }
   const dir = join(nitroConfig.rootDir, '.wrangler/dev')
   const path = join(dir, 'wrangler.json')

--- a/apps/cms/nuxt.config.ts
+++ b/apps/cms/nuxt.config.ts
@@ -1,4 +1,34 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function writeDevWranglerConfig(nitroConfig: {
+  dev?: boolean
+  rootDir?: string
+  compatibilityDate?: { cloudflare?: string, default?: string }
+  cloudflare?: { deployConfig?: boolean, wrangler?: Record<string, unknown> }
+}) {
+  if (!nitroConfig.dev || !nitroConfig.cloudflare?.deployConfig || !nitroConfig.rootDir) {
+    return
+  }
+  const wrangler = { ...(nitroConfig.cloudflare.wrangler ?? {}) }
+  // Workflows need a deployed `script_name`; omit them in local getPlatformProxy
+  // to avoid Wrangler’s noisy “not available in local development” warning.
+  delete wrangler.workflows
+  const devWrangler = {
+    name: 'jdc-cms-local',
+    compatibility_date:
+      nitroConfig.compatibilityDate?.cloudflare
+      ?? nitroConfig.compatibilityDate?.default
+      ?? '2026-05-27',
+    ...wrangler,
+  }
+  const dir = join(nitroConfig.rootDir, '.wrangler/dev')
+  const path = join(dir, 'wrangler.json')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(path, JSON.stringify(devWrangler, null, 2))
+}
+
 export default defineNuxtConfig({
   devServer: {
     port: 3001
@@ -60,6 +90,10 @@ export default defineNuxtConfig({
     compatibilityDate: '2026-05-27',
     cloudflare: {
       deployConfig: true,
+      dev: {
+        // Generated on dev start from `cloudflare.wrangler` below (bindings-only for getPlatformProxy).
+        configPath: '.wrangler/dev/wrangler.json',
+      },
       wrangler: {
         compatibility_flags: ['nodejs_compat'],
         d1_databases: [
@@ -83,6 +117,7 @@ export default defineNuxtConfig({
         ],
         ai: {
           binding: 'AI',
+          remote: true,
         },
         workflows: [
           {
@@ -131,5 +166,11 @@ export default defineNuxtConfig({
       service: 'journalducuistot-cms',
     },
     include: ['/api/**'],
+  },
+
+  hooks: {
+    'nitro:config'(nitroConfig) {
+      writeDevWranglerConfig(nitroConfig)
+    },
   },
 })

--- a/apps/cms/server/api/completion.post.ts
+++ b/apps/cms/server/api/completion.post.ts
@@ -1,8 +1,8 @@
-import { createTextStreamResponse, streamText } from 'ai'
+import { generateText, streamText } from 'ai'
+import { Readable } from 'node:stream'
 import type { H3Event } from 'h3'
 import { z } from 'zod'
 import { EDITOR_COMPLETION_MODES } from '../../shared/editor-completion-modes'
-import { WORKERS_AI_MODEL } from '../../shared/workers-ai-model'
 import {
   buildEditorCompletionConfig,
   truncateEditorPrompt,
@@ -11,6 +11,11 @@ import {
 import { getClientIp } from '../utils/client-ip'
 import { getCloudflareEnv } from '../utils/cloudflare-env'
 import { createCmsWorkersAI } from '../utils/cms-workers-ai'
+import {
+  isCreativeEditorCompletionMode,
+  resolveEditorCompletionModelId,
+  resolveVisibleCompletionText,
+} from '../utils/editor-completion-output'
 import { createApiError } from '../utils/errors'
 import { requireEditor } from '../utils/http-auth'
 import { useKvStore } from '../utils/kv'
@@ -45,6 +50,46 @@ function resolveCompletionGatewayId(event: H3Event, envGatewayId?: string): stri
   }
   const fromConfig = useRuntimeConfig(event).cmsAiGatewayId
   return typeof fromConfig === 'string' && fromConfig.length > 0 ? fromConfig : null
+}
+
+/**
+ * Workers AI + Nitro: `createTextStreamResponse(Web Response)` often yields an
+ * empty body under the Node Cloudflare-dev proxy. Pipe the async text stream
+ * through a Node Readable instead (same client protocol: plain text chunks).
+ */
+function sendPlainTextCompletionStream(event: H3Event, textStream: AsyncIterable<string>) {
+  setResponseHeader(event, 'Content-Type', 'text/plain; charset=utf-8')
+  setResponseHeader(event, 'Cache-Control', 'no-cache')
+  return sendStream(event, Readable.from(textStream))
+}
+
+/**
+ * Stream visible text for TipTap. Reasoning deltas stay server-side; if the
+ * model never emits content tokens, fall back once to recovered answer text.
+ */
+async function* streamVisibleEditorText(
+  result: ReturnType<typeof streamText>,
+): AsyncGenerator<string> {
+  let emitted = false
+  for await (const chunk of result.textStream) {
+    if (chunk) {
+      emitted = true
+      yield chunk
+    }
+  }
+
+  if (emitted) {
+    return
+  }
+
+  const [text, reasoningText] = await Promise.all([
+    result.text,
+    result.reasoningText,
+  ])
+  const visible = resolveVisibleCompletionText({ text, reasoningText })
+  if (visible) {
+    yield visible
+  }
 }
 
 export default defineEventHandler(async (event) => {
@@ -86,6 +131,8 @@ export default defineEventHandler(async (event) => {
   )
   const prompt = truncateEditorPrompt(parsed.data.prompt)
   const gatewayId = resolveCompletionGatewayId(event, env.CMS_AI_GATEWAY_ID)
+  const modelId = resolveEditorCompletionModelId(mode)
+  const creative = isCreativeEditorCompletionMode(mode)
 
   const workersai = createCmsWorkersAI(env.AI, {
     gatewayId,
@@ -93,18 +140,86 @@ export default defineEventHandler(async (event) => {
     metadata: {
       surface: 'editor-completion',
       mode,
+      model: modelId,
       userId: session.user.id,
       ...(parsed.data.language ? { language: parsed.data.language } : {}),
     },
   })
 
-  const result = streamText({
-    model: workersai(WORKERS_AI_MODEL),
+  const model = workersai(modelId)
+  // Continuer / Développer: keep Gemma reasoning (low effort) — TipTap only
+  // receives visible `text` (with reasoning fallback if content is empty).
+  // Mechanical transforms: disable reasoning on the instruct model.
+  const shared = {
+    model,
     system,
     prompt,
     maxOutputTokens,
     temperature: mode === 'continue' ? 0.35 : 0.2,
+    ...(creative
+      ? {
+          reasoning: 'low' as const,
+          providerOptions: {
+            'workers-ai': {
+              reasoning_effort: 'low' as const,
+            },
+          },
+        }
+      : {
+          reasoning: 'none' as const,
+          providerOptions: {
+            'workers-ai': {
+              reasoning_effort: null,
+            },
+          },
+        }),
+  }
+
+  // Local Cloudflare-dev AI proxy: streaming often returns an empty body even
+  // when generateText works. Prefer a buffered response in dev; stream in prod.
+  if (import.meta.dev) {
+    try {
+      const generated = await generateText(shared)
+      const visible = resolveVisibleCompletionText({
+        text: generated.text,
+        reasoningText: generated.reasoningText,
+      })
+      if (!visible) {
+        console.error('[completion] empty Workers AI response', {
+          model: modelId,
+          mode,
+          finishReason: generated.finishReason,
+          usage: generated.usage,
+          textLen: generated.text?.length ?? 0,
+          reasoningLen: generated.reasoningText?.length ?? 0,
+        })
+        throw createError({
+          statusCode: 502,
+          message: 'Workers AI a renvoyé une réponse vide.',
+        })
+      }
+      setResponseHeader(event, 'Content-Type', 'text/plain; charset=utf-8')
+      return visible
+    }
+    catch (error) {
+      if (error && typeof error === 'object' && 'statusCode' in error) {
+        throw error
+      }
+      console.error('[completion] generateText failed', error)
+      throw createError({
+        statusCode: 502,
+        message: 'Échec de génération Workers AI.',
+        cause: error,
+      })
+    }
+  }
+
+  const result = streamText({
+    ...shared,
+    onError: ({ error }) => {
+      console.error('[completion] streamText error', error)
+    },
   })
 
-  return createTextStreamResponse({ stream: result.textStream })
+  return sendPlainTextCompletionStream(event, streamVisibleEditorText(result))
 })

--- a/apps/cms/server/api/proofread.post.ts
+++ b/apps/cms/server/api/proofread.post.ts
@@ -37,10 +37,12 @@ export default defineEventHandler(async (event) => {
 
   const env = getCloudflareEnv(event)
   if (!env?.AI) {
-    throw createError({
-      statusCode: 503,
-      statusMessage: 'Workers AI n’est pas configuré.',
-    })
+    throw createApiError(
+      'INTERNAL_ERROR',
+      'Workers AI n’est pas configuré.',
+      undefined,
+      { why: 'Binding AI absent sur cet environnement.' },
+    )
   }
 
   const gatewayId = import.meta.dev
@@ -61,10 +63,11 @@ export default defineEventHandler(async (event) => {
   }
   catch (error) {
     console.error('[proofread] failed', error)
-    throw createError({
-      statusCode: 502,
-      message: 'Échec de l’analyse orthographique.',
-      cause: error,
-    })
+    throw createApiError(
+      'INTERNAL_ERROR',
+      'Échec de l’analyse orthographique.',
+      undefined,
+      { why: error instanceof Error ? error.message : 'Erreur inconnue' },
+    )
   }
 })

--- a/apps/cms/server/api/proofread.post.ts
+++ b/apps/cms/server/api/proofread.post.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod'
+import { runEditorProofread } from '../services/ai/editor-proofread'
+import { getClientIp } from '../utils/client-ip'
+import { getCloudflareEnv } from '../utils/cloudflare-env'
+import { createApiError } from '../utils/errors'
+import { requireEditor } from '../utils/http-auth'
+import { useKvStore } from '../utils/kv'
+import { createRequestRateLimiter } from '../utils/rate-limit'
+
+const LIMIT = {
+  prefix: 'proofread',
+  maxRequests: 30,
+  windowSeconds: 60,
+} as const
+
+const bodySchema = z.object({
+  text: z.string().min(1).max(12_000),
+})
+
+export default defineEventHandler(async (event) => {
+  const session = await requireEditor(event)
+  const ip = getClientIp(event)
+  const rate = await createRequestRateLimiter(useKvStore(event), LIMIT)
+    .consume(`${session.user.id}:${ip}`)
+  if (!rate.allowed) {
+    throw createApiError(
+      'FORBIDDEN',
+      'Trop de requêtes d’orthographe. Réessayez dans une minute.',
+      { retryAfterSeconds: LIMIT.windowSeconds },
+    )
+  }
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createApiError('VALIDATION_ERROR', 'Texte invalide.', parsed.error.flatten())
+  }
+
+  const env = getCloudflareEnv(event)
+  if (!env?.AI) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'Workers AI n’est pas configuré.',
+    })
+  }
+
+  const gatewayId = import.meta.dev
+    ? null
+    : (env.CMS_AI_GATEWAY_ID
+      || (typeof useRuntimeConfig(event).cmsAiGatewayId === 'string'
+        ? useRuntimeConfig(event).cmsAiGatewayId as string
+        : null))
+
+  try {
+    const corrections = await runEditorProofread({
+      ai: env.AI,
+      text: parsed.data.text,
+      gatewayId,
+      userId: session.user.id,
+    })
+    return { corrections }
+  }
+  catch (error) {
+    console.error('[proofread] failed', error)
+    throw createError({
+      statusCode: 502,
+      message: 'Échec de l’analyse orthographique.',
+      cause: error,
+    })
+  }
+})

--- a/apps/cms/server/services/ai/editor-completion.ts
+++ b/apps/cms/server/services/ai/editor-completion.ts
@@ -37,9 +37,11 @@ export function buildEditorCompletionConfig(
           'You are a writing assistant.',
           `Extend the text with useful culinary detail while keeping the same tone. ${FRENCH_COPY}`,
           PRESERVE_MARKDOWN,
+          'Put the extended article text in your final answer content (not only in reasoning).',
           'Only output the extended text, nothing else.',
         ].join(' '),
-        maxOutputTokens: 500,
+        // Headroom for Gemma reasoning tokens + visible extended text.
+        maxOutputTokens: 1024,
       }
     case 'reduce':
       return {
@@ -90,12 +92,15 @@ export function buildEditorCompletionConfig(
           FRENCH_COPY,
           'CRITICAL RULES:',
           '- Output ONLY the NEW text that comes AFTER the user\'s input',
-          '- NEVER repeat words from the end of the user\'s text',
+          '- NEVER repeat any words from the end of the user\'s text',
           '- Keep completions short (one sentence max)',
           '- Match the tone and style of the existing text',
+          '- Put the completion in your final answer content (not only in reasoning)',
           `- ${PRESERVE_MARKDOWN}`,
         ].join('\n'),
-        maxOutputTokens: 40,
+        // Gemma may spend tokens on reasoning first — budget must leave room
+        // for the visible one-sentence completion TipTap inserts.
+        maxOutputTokens: 256,
       }
     default: {
       const _exhaustive: never = mode

--- a/apps/cms/server/services/ai/editor-proofread.ts
+++ b/apps/cms/server/services/ai/editor-proofread.ts
@@ -2,7 +2,7 @@ import { generateText } from 'ai'
 import { z } from 'zod'
 import { EDITOR_COMPLETION_MODEL } from '../../../shared/workers-ai-model'
 import type { ProofreadCorrection } from '../../../shared/editor-completion-modes'
-import { isPlausibleSpellingFix } from '#shared/proofread-sanitize'
+import { isPlausibleSpellingFix, proofreadMaxSpanChars } from '../../../shared/proofread-sanitize'
 import { createCmsWorkersAI } from '../../utils/cms-workers-ai'
 import { resolveVisibleCompletionText } from '../../utils/editor-completion-output'
 
@@ -39,13 +39,24 @@ export function normalizeProofreadCorrections(
 
     const slice = text.slice(start, end)
     if (slice !== item.original) {
-      const fromCursor = text.indexOf(item.original, cursor)
-      const anywhere = fromCursor === -1 ? text.indexOf(item.original) : fromCursor
-      if (anywhere === -1) {
+      const candidates: number[] = []
+      let searchFrom = 0
+      while (searchFrom <= text.length) {
+        const idx = text.indexOf(item.original, searchFrom)
+        if (idx === -1) {
+          break
+        }
+        candidates.push(idx)
+        searchFrom = idx + 1
+      }
+      if (!candidates.length) {
         continue
       }
-      start = anywhere
-      end = anywhere + item.original.length
+      const preferred = candidates.reduce((best, idx) =>
+        Math.abs(idx - item.start) < Math.abs(best - item.start) ? idx : best,
+      )
+      start = preferred
+      end = preferred + item.original.length
     }
 
     if (end <= start || end > text.length) {
@@ -64,7 +75,7 @@ export function normalizeProofreadCorrections(
   }
 
   // Drop no-ops, rewrites, and huge spans (whole-paragraph "corrections" confuse the UI).
-  const maxSpan = Math.min(48, Math.max(12, Math.floor(text.length * 0.35)))
+  const maxSpan = proofreadMaxSpanChars(text.length)
   return out.filter((item) => {
     if (item.end - item.start > maxSpan) {
       return false
@@ -76,22 +87,39 @@ export function normalizeProofreadCorrections(
   })
 }
 
-function extractJsonObject(raw: string): unknown {
-  const trimmed = raw.trim()
+function tryParseJson(raw: string): unknown {
   try {
-    return JSON.parse(trimmed)
+    return JSON.parse(raw)
   }
   catch {
-    const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i)
-    if (fenced?.[1]) {
-      return JSON.parse(fenced[1].trim())
-    }
-    const brace = trimmed.match(/\{[\s\S]*\}/)
-    if (brace) {
-      return JSON.parse(brace[0])
-    }
-    throw new Error('Réponse proofread non JSON')
+    return undefined
   }
+}
+
+function extractJsonObject(raw: string): unknown {
+  const trimmed = raw.trim()
+  const direct = tryParseJson(trimmed)
+  if (direct !== undefined) {
+    return direct
+  }
+
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i)
+  if (fenced?.[1]) {
+    const parsed = tryParseJson(fenced[1].trim())
+    if (parsed !== undefined) {
+      return parsed
+    }
+  }
+
+  const brace = trimmed.match(/\{[\s\S]*\}/)
+  if (brace) {
+    const parsed = tryParseJson(brace[0])
+    if (parsed !== undefined) {
+      return parsed
+    }
+  }
+
+  throw new Error('Réponse proofread non JSON')
 }
 
 export async function runEditorProofread(options: {

--- a/apps/cms/server/services/ai/editor-proofread.ts
+++ b/apps/cms/server/services/ai/editor-proofread.ts
@@ -2,7 +2,7 @@ import { generateText } from 'ai'
 import { z } from 'zod'
 import { EDITOR_COMPLETION_MODEL } from '../../../shared/workers-ai-model'
 import type { ProofreadCorrection } from '../../../shared/editor-completion-modes'
-import { isPlausibleSpellingFix } from '../../../shared/proofread-sanitize'
+import { isPlausibleSpellingFix } from '#shared/proofread-sanitize'
 import { createCmsWorkersAI } from '../../utils/cms-workers-ai'
 import { resolveVisibleCompletionText } from '../../utils/editor-completion-output'
 

--- a/apps/cms/server/services/ai/editor-proofread.ts
+++ b/apps/cms/server/services/ai/editor-proofread.ts
@@ -1,0 +1,161 @@
+import { generateText } from 'ai'
+import { z } from 'zod'
+import { EDITOR_COMPLETION_MODEL } from '../../../shared/workers-ai-model'
+import type { ProofreadCorrection } from '../../../shared/editor-completion-modes'
+import { isPlausibleSpellingFix } from '../../../shared/proofread-sanitize'
+import { createCmsWorkersAI } from '../../utils/cms-workers-ai'
+import { resolveVisibleCompletionText } from '../../utils/editor-completion-output'
+
+const proofreadItemSchema = z.object({
+  original: z.string().min(1),
+  suggestion: z.string().min(1),
+  message: z.string().min(1).max(200),
+  start: z.number().int().nonnegative(),
+  end: z.number().int().positive(),
+})
+
+const proofreadPayloadSchema = z.object({
+  corrections: z.array(proofreadItemSchema).max(40),
+})
+
+function makeId(index: number, original: string): string {
+  return `pr-${index}-${original.slice(0, 12)}`
+}
+
+/**
+ * Locate each correction inside `text` (prefer model offsets, fall back to indexOf).
+ */
+export function normalizeProofreadCorrections(
+  text: string,
+  raw: z.infer<typeof proofreadPayloadSchema>['corrections'],
+): ProofreadCorrection[] {
+  const out: ProofreadCorrection[] = []
+  let cursor = 0
+
+  for (let i = 0; i < raw.length; i++) {
+    const item = raw[i]!
+    let start = item.start
+    let end = item.end
+
+    const slice = text.slice(start, end)
+    if (slice !== item.original) {
+      const fromCursor = text.indexOf(item.original, cursor)
+      const anywhere = fromCursor === -1 ? text.indexOf(item.original) : fromCursor
+      if (anywhere === -1) {
+        continue
+      }
+      start = anywhere
+      end = anywhere + item.original.length
+    }
+
+    if (end <= start || end > text.length) {
+      continue
+    }
+
+    out.push({
+      id: makeId(i, item.original),
+      original: item.original,
+      suggestion: item.suggestion,
+      message: item.message,
+      start,
+      end,
+    })
+    cursor = end
+  }
+
+  // Drop no-ops, rewrites, and huge spans (whole-paragraph "corrections" confuse the UI).
+  const maxSpan = Math.min(48, Math.max(12, Math.floor(text.length * 0.35)))
+  return out.filter((item) => {
+    if (item.end - item.start > maxSpan) {
+      return false
+    }
+    if (text.slice(item.start, item.end) !== item.original) {
+      return false
+    }
+    return isPlausibleSpellingFix(item.original, item.suggestion)
+  })
+}
+
+function extractJsonObject(raw: string): unknown {
+  const trimmed = raw.trim()
+  try {
+    return JSON.parse(trimmed)
+  }
+  catch {
+    const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i)
+    if (fenced?.[1]) {
+      return JSON.parse(fenced[1].trim())
+    }
+    const brace = trimmed.match(/\{[\s\S]*\}/)
+    if (brace) {
+      return JSON.parse(brace[0])
+    }
+    throw new Error('Réponse proofread non JSON')
+  }
+}
+
+export async function runEditorProofread(options: {
+  ai: Ai
+  text: string
+  gatewayId?: string | null
+  userId: string
+}): Promise<ProofreadCorrection[]> {
+  const workersai = createCmsWorkersAI(options.ai, {
+    gatewayId: options.gatewayId ?? null,
+    cacheTtl: 3600,
+    metadata: {
+      surface: 'editor-proofread',
+      userId: options.userId,
+    },
+  })
+
+  const system = [
+    'Tu es un correcteur orthographique et grammatical pour un blog de cuisine francophone (français de France, FR-FR).',
+    'Le texte fourni est déjà en français : ne le traduis jamais, ne le réécris jamais, ne propose aucun anglicisme.',
+    'Signale UNIQUEMENT des fautes réelles : accents manquants, typos, accords (genre/nombre), conjugaison.',
+    'Si le français est correct, renvoie exactement {"corrections":[]}.',
+    'Réponds UNIQUEMENT avec un JSON valide de cette forme :',
+    '{"corrections":[{"original":"...","suggestion":"...","message":"...","start":0,"end":5}]}',
+    'Règles strictes :',
+    '- original = sous-chaîne exacte du texte (un seul mot, le plus court possible)',
+    '- suggestion = même mot corrigé (proche : accent, lettre manquante, accord)',
+    '- start/end = offsets caractères 0-based dans le texte d’entrée',
+    '- message = courte explication en français',
+    '- INTERDIT : synonymes, style, ton, emoji, ponctuation « préférée », reformulation',
+    '- INTERDIT : signaler un mot français correct',
+    '- INTERDIT : correction qui couvre une phrase ou un paragraphe entier',
+  ].join('\n')
+
+  const generated = await generateText({
+    model: workersai(EDITOR_COMPLETION_MODEL),
+    system,
+    prompt: [
+      'Vérifie ce texte en français de France. Ne renvoie des corrections que s’il y a de vraies fautes.',
+      '',
+      options.text,
+    ].join('\n'),
+    maxOutputTokens: 800,
+    temperature: 0,
+    reasoning: 'none',
+    providerOptions: {
+      'workers-ai': {
+        reasoning_effort: null,
+      },
+    },
+  })
+
+  const visible = resolveVisibleCompletionText({
+    text: generated.text,
+    reasoningText: generated.reasoningText,
+  })
+  if (!visible) {
+    return []
+  }
+
+  const parsed = proofreadPayloadSchema.safeParse(extractJsonObject(visible))
+  if (!parsed.success) {
+    return []
+  }
+
+  return normalizeProofreadCorrections(options.text, parsed.data.corrections)
+}

--- a/apps/cms/server/services/ai/editor-proofread.ts
+++ b/apps/cms/server/services/ai/editor-proofread.ts
@@ -2,7 +2,7 @@ import { generateText } from 'ai'
 import { z } from 'zod'
 import { EDITOR_COMPLETION_MODEL } from '../../../shared/workers-ai-model'
 import type { ProofreadCorrection } from '../../../shared/editor-completion-modes'
-import { isPlausibleSpellingFix, proofreadMaxSpanChars } from '../../../shared/proofread-sanitize'
+import { isPlausibleSpellingFix, proofreadMaxSpanChars } from '#shared/proofread-sanitize'
 import { createCmsWorkersAI } from '../../utils/cms-workers-ai'
 import { resolveVisibleCompletionText } from '../../utils/editor-completion-output'
 

--- a/apps/cms/server/utils/editor-completion-output.ts
+++ b/apps/cms/server/utils/editor-completion-output.ts
@@ -1,0 +1,76 @@
+import type { EditorCompletionMode } from '../../shared/editor-completion-modes'
+import {
+  EDITOR_COMPLETION_MODEL,
+  WORKERS_AI_MODEL,
+} from '../../shared/workers-ai-model'
+
+/** Creative editor modes — Gemma reasoning helps quality. */
+const CREATIVE_EDITOR_MODES = new Set<EditorCompletionMode>(['continue', 'extend'])
+
+export function isCreativeEditorCompletionMode(mode: EditorCompletionMode): boolean {
+  return CREATIVE_EDITOR_MODES.has(mode)
+}
+
+/**
+ * Continuer / Développer → Gemma (reasoning OK).
+ * Orthographe / Raccourcir / … → fast instruct model (no reasoning needed).
+ */
+export function resolveEditorCompletionModelId(mode: EditorCompletionMode) {
+  return isCreativeEditorCompletionMode(mode)
+    ? WORKERS_AI_MODEL
+    : EDITOR_COMPLETION_MODEL
+}
+
+/**
+ * Prefer model `text` (what TipTap inserts). If a reasoning model spent its
+ * budget in the reasoning channel and left content empty, recover a usable
+ * answer from reasoning — never dump raw chain-of-thought when a clearer
+ * final span exists.
+ */
+export function resolveVisibleCompletionText(parts: {
+  text?: string | null
+  reasoningText?: string | null
+}): string {
+  const text = parts.text?.trim() ?? ''
+  if (text) {
+    return text
+  }
+
+  const reasoning = parts.reasoningText?.trim() ?? ''
+  if (!reasoning) {
+    return ''
+  }
+
+  return extractAnswerFromReasoning(reasoning)
+}
+
+/**
+ * Pull a final answer out of CoT / reasoning blobs.
+ * Prefers explicit answer markers, otherwise the last substantial paragraph.
+ */
+export function extractAnswerFromReasoning(reasoning: string): string {
+  const marked = reasoning.match(
+    /(?:^|\n)\s*(?:final\s*answer|answer|réponse|completion|output)\s*[:：]\s*([\s\S]+)$/i,
+  )
+  if (marked?.[1]?.trim()) {
+    return marked[1].trim()
+  }
+
+  const fenced = [...reasoning.matchAll(/```(?:[\w-]+)?\n([\s\S]*?)```/g)]
+  const lastFence = fenced.at(-1)?.[1]?.trim()
+  if (lastFence) {
+    return lastFence
+  }
+
+  const paragraphs = reasoning
+    .split(/\n\s*\n/)
+    .map(part => part.trim())
+    .filter(Boolean)
+
+  const prose = [...paragraphs].reverse().find(paragraph =>
+    paragraph.length >= 12
+    && !/^(let me|i need|i should|the user|thinking|step\s*\d)/i.test(paragraph),
+  )
+
+  return prose ?? paragraphs.at(-1) ?? reasoning.trim()
+}

--- a/apps/cms/server/utils/editor-completion-output.ts
+++ b/apps/cms/server/utils/editor-completion-output.ts
@@ -62,15 +62,5 @@ export function extractAnswerFromReasoning(reasoning: string): string {
     return lastFence
   }
 
-  const paragraphs = reasoning
-    .split(/\n\s*\n/)
-    .map(part => part.trim())
-    .filter(Boolean)
-
-  const prose = [...paragraphs].reverse().find(paragraph =>
-    paragraph.length >= 12
-    && !/^(let me|i need|i should|the user|thinking|step\s*\d)/i.test(paragraph),
-  )
-
-  return prose ?? paragraphs.at(-1) ?? reasoning.trim()
+  return ''
 }

--- a/apps/cms/shared/editor-completion-modes.ts
+++ b/apps/cms/shared/editor-completion-modes.ts
@@ -25,6 +25,38 @@ export const EDITOR_TRANSFORM_MODES = [
 
 export type EditorTransformMode = (typeof EDITOR_TRANSFORM_MODES)[number]
 
+/**
+ * Reformulation modes that offer two streamed alternatives for the editor to pick.
+ * Orthographe (`fix`) uses the structured proofread flow instead.
+ */
+export const EDITOR_VARIANT_MODES = [
+  'extend',
+  'reduce',
+  'simplify',
+  'summarize',
+  'translate',
+] as const
+
+export type EditorVariantMode = (typeof EDITOR_VARIANT_MODES)[number]
+
 export function isEditorTransformMode(mode: EditorCompletionMode): mode is EditorTransformMode {
   return (EDITOR_TRANSFORM_MODES as readonly string[]).includes(mode)
+}
+
+export function isEditorVariantMode(mode: EditorCompletionMode): mode is EditorVariantMode {
+  return (EDITOR_VARIANT_MODES as readonly string[]).includes(mode)
+}
+
+export interface ProofreadCorrection {
+  /** Unique id for UI keys. */
+  id: string
+  /** Exact substring from the selected text. */
+  original: string
+  /** Suggested replacement. */
+  suggestion: string
+  /** Short French explanation. */
+  message: string
+  /** UTF-16 offsets within the selected plain text. */
+  start: number
+  end: number
 }

--- a/apps/cms/shared/proofread-sanitize.ts
+++ b/apps/cms/shared/proofread-sanitize.ts
@@ -51,3 +51,13 @@ export function isPlausibleSpellingFix(original: string, suggestion: string): bo
       : Math.min(3, Math.ceil(left.length * 0.25))
   return dist > 0 && dist <= maxDist
 }
+
+export const PROOFREAD_MAX_CORRECTION_CHARS = 48
+
+/** Max character span for a single orthographe correction (aligned client + server). */
+export function proofreadMaxSpanChars(textLength: number): number {
+  return Math.min(
+    PROOFREAD_MAX_CORRECTION_CHARS,
+    Math.max(12, Math.floor(textLength * 0.35)),
+  )
+}

--- a/apps/cms/shared/proofread-sanitize.ts
+++ b/apps/cms/shared/proofread-sanitize.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared orthographe filters — keep server normalize + client sanitize aligned.
+ */
+
+export function levenshtein(a: string, b: string): number {
+  if (a === b) {
+    return 0
+  }
+  if (!a.length) {
+    return b.length
+  }
+  if (!b.length) {
+    return a.length
+  }
+
+  const prev = Array.from({ length: b.length + 1 }, (_, j) => j)
+  for (let i = 1; i <= a.length; i++) {
+    let prevDiag = prev[0]!
+    prev[0] = i
+    for (let j = 1; j <= b.length; j++) {
+      const temp = prev[j]!
+      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1
+      prev[j] = Math.min(prev[j]! + 1, prev[j - 1]! + 1, prevDiag + cost)
+      prevDiag = temp
+    }
+  }
+  return prev[b.length]!
+}
+
+/** Small edit distance = likely accent/typo/agreement, not a rewrite. */
+export function isPlausibleSpellingFix(original: string, suggestion: string): boolean {
+  const left = original.trim()
+  const right = suggestion.trim()
+  if (!left || !right || left === right) {
+    return false
+  }
+  // Orthographe FR: un seul token (éventuellement avec trait d'union), pas de reformulation.
+  if (/\s/.test(left) || /\s/.test(right)) {
+    return false
+  }
+  // Refuse ASCII→ASCII synonym swaps that only share length (noir→vert).
+  if (Math.abs(left.length - right.length) > Math.max(2, Math.floor(left.length * 0.35))) {
+    return false
+  }
+  const dist = levenshtein(left.toLowerCase(), right.toLowerCase())
+  // Short French words: allow 1 edit (accent / letter). Longer: up to 2–3.
+  const maxDist = left.length <= 5
+    ? 1
+    : left.length <= 10
+      ? 2
+      : Math.min(3, Math.ceil(left.length * 0.25))
+  return dist > 0 && dist <= maxDist
+}

--- a/apps/cms/shared/public-site-paths.ts
+++ b/apps/cms/shared/public-site-paths.ts
@@ -24,11 +24,9 @@ export function pagePublicPath(slug: string, parent?: NestedPageParent | null): 
 }
 
 export function articlePublicPath(articleSlug: string, categorySlug?: string | null): string {
-  const category = categorySlug?.trim()
-  if (category) {
-    return `/blog/${category}/${articleSlug}`
-  }
-  return `/blog/${articleSlug}`
+  const slug = articleSlug.trim()
+  const category = categorySlug?.trim() || 'uncategorized'
+  return `/blog/${category}/${slug}`
 }
 
 export function recipePublicPath(recipeSlug: string): string {

--- a/apps/cms/shared/workers-ai-model.ts
+++ b/apps/cms/shared/workers-ai-model.ts
@@ -1,8 +1,17 @@
 /**
- * Default Workers AI model for CMS LLM features (generation + editor completion).
+ * Default Workers AI model for long-form generation + creative editor modes
+ * (Continuer / Développer). Reasoning-capable — callers must prefer `text`
+ * and fall back via `resolveVisibleCompletionText` when content is empty.
  * @see https://developers.cloudflare.com/workers-ai/models/gemma-4-26b-a4b-it/
  */
 export const WORKERS_AI_MODEL = '@cf/google/gemma-4-26b-a4b-it' as const
+
+/**
+ * Mechanical editor transforms (Orthographe, Raccourcir, Simplifier, …) —
+ * non-reasoning instruct model for fast, deterministic plain-text replacements.
+ * @see https://developers.cloudflare.com/workers-ai/models/llama-3.2-3b-instruct/
+ */
+export const EDITOR_COMPLETION_MODEL = '@cf/meta/llama-3.2-3b-instruct' as const
 
 /**
  * Cloudflare AI Gateway id — must match Alchemy `Cloudflare.AI.Gateway` in `infra/workers.ts`.

--- a/apps/cms/test/unit/editor-completion-output.test.ts
+++ b/apps/cms/test/unit/editor-completion-output.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EDITOR_COMPLETION_MODEL,
+  WORKERS_AI_MODEL,
+} from '../../shared/workers-ai-model'
+import {
+  extractAnswerFromReasoning,
+  isCreativeEditorCompletionMode,
+  resolveEditorCompletionModelId,
+  resolveVisibleCompletionText,
+} from '../../server/utils/editor-completion-output'
+
+describe('editor-completion-output', () => {
+  it('routes continue/extend to Gemma and transforms to instruct', () => {
+    expect(isCreativeEditorCompletionMode('continue')).toBe(true)
+    expect(isCreativeEditorCompletionMode('extend')).toBe(true)
+    expect(isCreativeEditorCompletionMode('fix')).toBe(false)
+    expect(resolveEditorCompletionModelId('continue')).toBe(WORKERS_AI_MODEL)
+    expect(resolveEditorCompletionModelId('extend')).toBe(WORKERS_AI_MODEL)
+    expect(resolveEditorCompletionModelId('fix')).toBe(EDITOR_COMPLETION_MODEL)
+  })
+
+  it('prefers visible text over reasoning', () => {
+    expect(resolveVisibleCompletionText({
+      text: ' suite du paragraphe.',
+      reasoningText: 'I should continue with food details...',
+    })).toBe('suite du paragraphe.')
+  })
+
+  it('recovers an answer from reasoning when text is empty', () => {
+    expect(resolveVisibleCompletionText({
+      text: '',
+      reasoningText: 'The user stopped mid-sentence.\n\nFinal answer: aromatisé au cumin et au paprika.',
+    })).toBe('aromatisé au cumin et au paprika.')
+  })
+
+  it('extracts the last prose paragraph from unstructured reasoning', () => {
+    expect(extractAnswerFromReasoning([
+      'Let me think about a natural continuation.',
+      '',
+      'I should keep the French cooking tone.',
+      '',
+      'servi avec une sauce au citron.',
+    ].join('\n'))).toBe('servi avec une sauce au citron.')
+  })
+})

--- a/apps/cms/test/unit/editor-completion-output.test.ts
+++ b/apps/cms/test/unit/editor-completion-output.test.ts
@@ -34,13 +34,13 @@ describe('editor-completion-output', () => {
     })).toBe('aromatisé au cumin et au paprika.')
   })
 
-  it('extracts the last prose paragraph from unstructured reasoning', () => {
+  it('does not treat unstructured reasoning as completion text', () => {
     expect(extractAnswerFromReasoning([
       'Let me think about a natural continuation.',
       '',
       'I should keep the French cooking tone.',
       '',
       'servi avec une sauce au citron.',
-    ].join('\n'))).toBe('servi avec une sauce au citron.')
+    ].join('\n'))).toBe('')
   })
 })

--- a/apps/cms/test/unit/editor-completion.test.ts
+++ b/apps/cms/test/unit/editor-completion.test.ts
@@ -11,9 +11,13 @@ import {
 describe('editor-completion', () => {
   it('builds continue mode with short token budget', () => {
     const config = buildEditorCompletionConfig('continue')
-    expect(config.maxOutputTokens).toBe(40)
+    expect(config.maxOutputTokens).toBe(256)
     expect(config.system).toContain('inline autocompletions')
     expect(config.cacheTtl).toBeUndefined()
+  })
+
+  it('gives extend enough tokens for Gemma reasoning + text', () => {
+    expect(buildEditorCompletionConfig('extend').maxOutputTokens).toBe(1024)
   })
 
   it('includes target language for translate mode', () => {

--- a/apps/cms/test/unit/editor-proofread-map.test.ts
+++ b/apps/cms/test/unit/editor-proofread-map.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import { Schema } from '@tiptap/pm/model'
+import {
+  plainOffsetToDocPos,
+  proofreadRangesInDoc,
+  sanitizeProofreadCorrections,
+} from '../../app/utils/editor-proofread-map'
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { content: 'inline*', group: 'block' },
+    text: { group: 'inline' },
+  },
+})
+
+function docWithText(text: string) {
+  return schema.node('doc', null, [
+    schema.node('paragraph', null, text ? [schema.text(text)] : []),
+  ])
+}
+
+describe('sanitizeProofreadCorrections', () => {
+  it('drops no-ops and whole-paragraph spans', () => {
+    const text = 'Il est important de noter que le thé contient de la caféine.'
+    const result = sanitizeProofreadCorrections(text, [
+      {
+        id: 'a',
+        original: text,
+        suggestion: 'Autre chose',
+        message: 'Trop large',
+        start: 0,
+        end: text.length,
+      },
+      {
+        id: 'b',
+        original: 'caféine',
+        suggestion: 'caféine',
+        message: 'No-op',
+        start: text.indexOf('caféine'),
+        end: text.indexOf('caféine') + 'caféine'.length,
+      },
+      {
+        id: 'c',
+        original: 'thé',
+        suggestion: 'thé',
+        message: 'No-op 2',
+        start: text.indexOf('thé'),
+        end: text.indexOf('thé') + 3,
+      },
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('keeps a short real typo', () => {
+    const text = 'Le poulait est delicieux.'
+    const start = text.indexOf('poulait')
+    const result = sanitizeProofreadCorrections(text, [{
+      id: '1',
+      original: 'poulait',
+      suggestion: 'poulet',
+      message: 'Orthographe',
+      start,
+      end: start + 7,
+    }])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.suggestion).toBe('poulet')
+  })
+
+  it('drops phrase rewrites and unrelated word swaps', () => {
+    const text = 'Que vous soyez un fan de thé noir ou que vous découvriez.'
+    const result = sanitizeProofreadCorrections(text, [
+      {
+        id: '1',
+        original: 'ou que',
+        suggestion: 'ou si',
+        message: 'Style',
+        start: text.indexOf('ou que'),
+        end: text.indexOf('ou que') + 6,
+      },
+      {
+        id: '2',
+        original: 'noir',
+        suggestion: 'vert',
+        message: 'Pas une faute',
+        start: text.indexOf('noir'),
+        end: text.indexOf('noir') + 4,
+      },
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('drops overlapping later spans', () => {
+    const text = 'abc def ghi'
+    const result = sanitizeProofreadCorrections(text, [
+      {
+        id: '1',
+        original: 'abc',
+        suggestion: 'abd',
+        message: 'a',
+        start: 0,
+        end: 3,
+      },
+      {
+        id: '2',
+        original: 'bc d',
+        suggestion: 'xx',
+        message: 'overlap',
+        start: 1,
+        end: 5,
+      },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.id).toBe('1')
+  })
+})
+
+describe('plainOffsetToDocPos / proofreadRangesInDoc', () => {
+  it('maps plain offsets inside a single paragraph', () => {
+    const text = 'Le poulait est bon.'
+    const doc = docWithText(text)
+    // doc pos: 0=doc, 1=paragraph open, 2=first char
+    const rangeFrom = 1
+    const rangeTo = 1 + text.length
+    const start = text.indexOf('poulait')
+    const end = start + 'poulait'.length
+
+    const from = plainOffsetToDocPos(doc, rangeFrom, rangeTo, start)
+    const to = plainOffsetToDocPos(doc, rangeFrom, rangeTo, end)
+    expect(doc.textBetween(from, to)).toBe('poulait')
+
+    const ranges = proofreadRangesInDoc(doc, rangeFrom, rangeTo, [
+      { id: 'x', start, end },
+    ])
+    expect(ranges).toEqual([{ from, to, id: 'x' }])
+  })
+})

--- a/apps/cms/test/unit/editor-proofread.test.ts
+++ b/apps/cms/test/unit/editor-proofread.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeProofreadCorrections } from '../../server/services/ai/editor-proofread'
+
+describe('normalizeProofreadCorrections', () => {
+  it('keeps valid offsets', () => {
+    const text = 'Le poulait est delicieux.'
+    const result = normalizeProofreadCorrections(text, [{
+      original: 'poulait',
+      suggestion: 'poulet',
+      message: 'Orthographe',
+      start: 3,
+      end: 10,
+    }])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.suggestion).toBe('poulet')
+  })
+
+  it('repairs bad offsets via indexOf', () => {
+    const text = 'Le poulait est delicieux.'
+    const result = normalizeProofreadCorrections(text, [{
+      original: 'delicieux',
+      suggestion: 'délicieux',
+      message: 'Accent',
+      start: 0,
+      end: 1,
+    }])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.start).toBe(text.indexOf('delicieux'))
+  })
+
+  it('drops no-ops and oversized spans', () => {
+    const text = 'Une phrase correcte assez longue pour tester le filtre des spans trop larges.'
+    const result = normalizeProofreadCorrections(text, [
+      {
+        original: 'Une',
+        suggestion: 'Une',
+        message: 'No-op',
+        start: 0,
+        end: 3,
+      },
+      {
+        original: text,
+        suggestion: 'Autre',
+        message: 'Trop large',
+        start: 0,
+        end: text.length,
+      },
+    ])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/apps/cms/test/unit/editor-proofread.test.ts
+++ b/apps/cms/test/unit/editor-proofread.test.ts
@@ -15,7 +15,7 @@ describe('normalizeProofreadCorrections', () => {
     expect(result[0]?.suggestion).toBe('poulet')
   })
 
-  it('repairs bad offsets via indexOf', () => {
+  it('repairs bad offsets via closest indexOf match', () => {
     const text = 'Le poulait est delicieux.'
     const result = normalizeProofreadCorrections(text, [{
       original: 'delicieux',
@@ -26,6 +26,19 @@ describe('normalizeProofreadCorrections', () => {
     }])
     expect(result).toHaveLength(1)
     expect(result[0]?.start).toBe(text.indexOf('delicieux'))
+  })
+
+  it('picks the occurrence nearest model start when duplicated', () => {
+    const text = 'foo bar foo baz'
+    const result = normalizeProofreadCorrections(text, [{
+      original: 'foo',
+      suggestion: 'fou',
+      message: 'Typo',
+      start: 8,
+      end: 11,
+    }])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.start).toBe(8)
   })
 
   it('drops no-ops and oversized spans', () => {

--- a/apps/cms/test/unit/public-site-paths.test.ts
+++ b/apps/cms/test/unit/public-site-paths.test.ts
@@ -12,6 +12,7 @@ describe('public-site-paths', () => {
 
   it('builds article and recipe paths', () => {
     expect(articlePublicPath('mon-article', 'desserts')).toBe('/blog/desserts/mon-article')
+    expect(articlePublicPath('mon-article')).toBe('/blog/uncategorized/mon-article')
     expect(recipePublicPath('tarte')).toBe('/recette/tarte')
   })
 })

--- a/apps/cms/vitest.config.ts
+++ b/apps/cms/vitest.config.ts
@@ -5,6 +5,9 @@ import { playwright } from '@vitest/browser-playwright'
 
 export default defineConfig({
   resolve: {
+    alias: {
+      '#shared': fileURLToPath(new URL('./shared', import.meta.url)),
+    },
     tsconfig: fileURLToPath(new URL('./.nuxt/tsconfig.server.json', import.meta.url)),
   },
   test: {

--- a/apps/web/app/components/PrevAndNext.vue
+++ b/apps/web/app/components/PrevAndNext.vue
@@ -1,18 +1,23 @@
 <script lang="ts" setup>
-const { prev, next } = defineProps({
-  prev: String,
-  next: String,
-});
+const { prev, next } = defineProps<{
+  prev?: string;
+  next?: string;
+}>();
+
+const hasPrev = computed(() => Boolean(prev?.trim()) && prev !== "undefined");
+const hasNext = computed(() => Boolean(next?.trim()) && next !== "undefined");
 </script>
 
 <template>
   <div
+    v-if="hasPrev || hasNext"
     class="flex relative justify-between items-center p-0 my-4 leading-6 align-baseline border-0 text-stone-500"
   >
     <NuxtLink
+      v-if="hasPrev"
       itemprop="url"
       class="flex relative items-center h-4 text-black align-baseline border-0 cursor-pointer hover:text-stone-500 after:content-[''] after:absolute after:-z-10 after:w-1/2 after:h-full after:bg-amber-200 after:transition-all after:ease-out hover:after:w-full"
-      :to="`/blog/${prev}`"
+      :to="prev!"
     >
       <Icon name="heroicons:arrow-long-left-solid" class="h-4 w-4 mr-3 ml-0" />
       <span
@@ -21,10 +26,12 @@ const { prev, next } = defineProps({
         >Previous</span
       >
     </NuxtLink>
+    <span v-else />
     <NuxtLink
+      v-if="hasNext"
       itemprop="url"
       class="flex relative flex-row-reverse items-center h-4 text-black align-baseline border-0 cursor-pointer hover:text-stone-500 after:content-[''] after:absolute after:w-1/2 after:-z-10 after:h-full after:bg-amber-200 after:transition-all after:ease-out hover:after:w-full"
-      :to="`/blog/${next}`"
+      :to="next!"
     >
       <Icon name="heroicons:arrow-long-right" class="h-4 w-4 mr-0 ml-3" />
       <span

--- a/apps/web/app/components/Share.vue
+++ b/apps/web/app/components/Share.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { SITE_AUTHOR_NAME } from "~/composables/useSitePageUrl";
+
 const props = defineProps({
   date: {
     type: String,
@@ -21,6 +23,7 @@ const dateFormatted = useDateFormat(props.date, "DD-MM-YYYY");
       <nuxt-img
         data-del="avatar"
         src="/img/author.jpg"
+        :alt="`Portrait de ${SITE_AUTHOR_NAME}`"
         class="max-w-full h-auto leading-6 text-black align-middle cursor-pointer rounded-full"
         height="48"
         width="48"

--- a/apps/web/app/components/article/Card.vue
+++ b/apps/web/app/components/article/Card.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { useReadingTime } from "~/composables/useReadingTime";
 import type { Article, Category, Cover } from "~/types/strapiMeta";
+import { articlePublicPath } from "~/utils/article-path";
 
 const { post } = defineProps<{
   post: Article;
@@ -33,6 +34,10 @@ const responsiveCover = computed(() => {
               `;
 });
 const { minutes } = useReadingTime(post.content || "");
+
+const articleLink = computed(() =>
+  articlePublicPath(post.slug, category.value?.slug),
+);
 </script>
 
 <template>
@@ -41,7 +46,7 @@ const { minutes } = useReadingTime(post.content || "");
       class="block lg:flex relative justify-center items-center p-0 m-0 leading-6 align-baseline border-0 text-stone-500">
       <div class="overflow-hidden flex-grow lg:basis-[44%] flex-shrink p-0 m-0 align-baseline border-0">
         <div class="p-0 m-0 align-baseline border-0">
-          <nuxt-link itemprop="url" :to="`blog/${category?.slug}/${post.slug}`"
+          <nuxt-link itemprop="url" :to="articleLink"
             class="p-0 m-0 text-black align-baseline border-0 cursor-pointer hover:text-stone-500" style="
               outline: 0px;
               text-decoration: none;
@@ -68,7 +73,7 @@ const { minutes } = useReadingTime(post.content || "");
         </div>
         <h3 itemprop="name" class="p-0 m-0 font-serif text-2xl font-normal text-black align-baseline break-words">
           <NuxtLink itemprop="url" class="p-0 m-0 align-baseline border-0 cursor-pointer hover:text-stone-500"
-            :to="`blog/${category?.slug}/${post.slug}`" style="
+            :to="articleLink" style="
               outline: 0px;
               text-decoration: none;
               transition: color 0.2s ease-out 0s;

--- a/apps/web/app/components/base/MarkdownContent.vue
+++ b/apps/web/app/components/base/MarkdownContent.vue
@@ -1,20 +1,24 @@
 <script lang="ts" setup>
+import { sanitizePublicMarkdown } from "~/utils/sanitize-markdown";
+
 const { markdown, tag = "div" } = defineProps<{
   markdown: string;
   tag?: string;
   class?: string;
 }>();
+
+const safeMarkdown = computed(() => sanitizePublicMarkdown(markdown));
 </script>
 
 <template>
   <Suspense>
     <component
       :is="tag"
-      v-if="markdown"
+      v-if="safeMarkdown"
       class="w-full prose md:prose-lg lg:prose-xl max-w-4xl"
       :class="$props.class"
     >
-      <BaseAppComark :markdown="markdown" />
+      <BaseAppComark :markdown="safeMarkdown" />
     </component>
   </Suspense>
 </template>

--- a/apps/web/app/components/preview/RecipeDisplay.vue
+++ b/apps/web/app/components/preview/RecipeDisplay.vue
@@ -118,7 +118,6 @@ const seoKeywords = computed(() => {
   <RecipeNutritional :data="formatedNutrition" />
   <LazyRecipeSteps :steps="steps" />
   <LazyCta />
-  <LazyPrevAndNext class="print:hidden" />
   <LazySectionYouMayAlsoLike :category="String(categoryRecipe.id ?? 'cuisine-africaine')" type-content="recipes"
     class="print:hidden" />
 </template>

--- a/apps/web/app/components/section/Sidebar.vue
+++ b/apps/web/app/components/section/Sidebar.vue
@@ -1,4 +1,6 @@
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+import { SITE_AUTHOR_NAME } from "~/composables/useSitePageUrl";
+</script>
 
 <template>
   <aside class="w-full lg:w-1/4 space-y-8">
@@ -12,6 +14,7 @@
       <nuxt-img
         data-del="avatar"
         src="/img/author.jpg"
+        :alt="`Portrait de ${SITE_AUTHOR_NAME}`"
         class="max-w-full h-auto rounded-full leading-6 text-center text-black align-middle cursor-pointer"
         height="138"
         width="138"

--- a/apps/web/app/composables/useLoadMeta.ts
+++ b/apps/web/app/composables/useLoadMeta.ts
@@ -1,5 +1,6 @@
 import type { MetaData, MetaOption } from "~/types/meta";
 import { absoluteSiteUrl, siteUrlOrigin } from "~/composables/useSitePageUrl";
+import { formatOpenGraphDateTime } from "~/utils/open-graph-date";
 
 export const useLoadMeta = (metaOption: MetaOption): MetaData => {
   const site = useSiteConfig();
@@ -25,7 +26,7 @@ export const useLoadMeta = (metaOption: MetaOption): MetaData => {
   const image =
     absoluteSiteUrl(site.url, metaOption.image) || defaultImage;
 
-  const isArticle = Boolean(metaOption.articleDatePublished);
+  const isArticle = Boolean(formatOpenGraphDateTime(metaOption.articleDatePublished));
 
   const metaData: MetaData = {
     type: isArticle ? "article" : "website",
@@ -51,11 +52,13 @@ export const useLoadMeta = (metaOption: MetaOption): MetaData => {
   if (metaOption.author) {
     metaData.author = metaOption.author;
   }
-  if (metaOption.articleDatePublished) {
-    metaData.articleDatePublished = metaOption.articleDatePublished;
+  const published = formatOpenGraphDateTime(metaOption.articleDatePublished);
+  const modified = formatOpenGraphDateTime(metaOption.articleDateModified);
+  if (published) {
+    metaData.articleDatePublished = published;
   }
-  if (metaOption.articleDateModified) {
-    metaData.articleDateModified = metaOption.articleDateModified;
+  if (modified) {
+    metaData.articleDateModified = modified;
   }
 
   return metaData;

--- a/apps/web/app/pages/preview.vue
+++ b/apps/web/app/pages/preview.vue
@@ -12,8 +12,8 @@ const { slug, type } = route.query;
 
 if (!slug || !type) {
   throw createError({
-    statusCode: 400,
-    statusMessage: "Missing required query parameters: slug and type",
+    statusCode: 404,
+    statusMessage: "Not Found",
   });
 }
 

--- a/apps/web/app/pages/recette/[slug].vue
+++ b/apps/web/app/pages/recette/[slug].vue
@@ -163,7 +163,6 @@ defineOgImage("Cooking", {
   <RecipeNutritional :data="formated" />
   <LazyRecipeSteps :steps="steps" />
   <LazyCta />
-  <LazyPrevAndNext class="print:hidden" />
   <LazySectionYouMayAlsoLike :category="String(categoryRecipe.id ?? 'cuisine-africaine')" type-content="recipes"
     class="print:hidden" />
 </template>

--- a/apps/web/app/utils/article-path.ts
+++ b/apps/web/app/utils/article-path.ts
@@ -1,0 +1,13 @@
+const FALLBACK_ARTICLE_CATEGORY = "uncategorized";
+
+/** Public blog URL for an article (`/blog/:category/:slug`). */
+export function articlePublicPath(
+  articleSlug: string,
+  categorySlug?: string | null,
+): string {
+  const slug = articleSlug.trim();
+  const category = categorySlug?.trim() || FALLBACK_ARTICLE_CATEGORY;
+  return `/blog/${category}/${slug}`;
+}
+
+export { FALLBACK_ARTICLE_CATEGORY };

--- a/apps/web/app/utils/open-graph-date.ts
+++ b/apps/web/app/utils/open-graph-date.ts
@@ -8,8 +8,8 @@ export function formatOpenGraphDateTime(value?: string | null): string | undefin
     return undefined
   }
 
-  const normalized = raw.includes('T') || raw.includes(' ')
-    ? raw.replace(' ', 'T')
+  const normalized = /[T\s]/.test(raw)
+    ? raw.replace(/\s+/, 'T')
     : `${raw}T12:00:00.000Z`
 
   const parsed = new Date(normalized)

--- a/apps/web/app/utils/open-graph-date.ts
+++ b/apps/web/app/utils/open-graph-date.ts
@@ -1,14 +1,21 @@
+const ISO_DATE_TIME
+  = /^\d{4}-\d{2}-\d{2}(?:[T\s]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/
+
 /** ISO 8601 datetime for Open Graph article:* and Twitter meta. */
 export function formatOpenGraphDateTime(value?: string | null): string | undefined {
-  const raw = value?.trim();
-  if (!raw) {
-    return undefined;
+  const raw = value?.trim()
+  if (!raw || !ISO_DATE_TIME.test(raw)) {
+    return undefined
   }
 
-  const parsed = new Date(raw);
+  const normalized = raw.includes('T') || raw.includes(' ')
+    ? raw.replace(' ', 'T')
+    : `${raw}T12:00:00.000Z`
+
+  const parsed = new Date(normalized)
   if (Number.isNaN(parsed.getTime())) {
-    return undefined;
+    return undefined
   }
 
-  return parsed.toISOString();
+  return parsed.toISOString()
 }

--- a/apps/web/app/utils/open-graph-date.ts
+++ b/apps/web/app/utils/open-graph-date.ts
@@ -1,0 +1,14 @@
+/** ISO 8601 datetime for Open Graph article:* and Twitter meta. */
+export function formatOpenGraphDateTime(value?: string | null): string | undefined {
+  const raw = value?.trim();
+  if (!raw) {
+    return undefined;
+  }
+
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+
+  return parsed.toISOString();
+}

--- a/apps/web/app/utils/redirect.ts
+++ b/apps/web/app/utils/redirect.ts
@@ -1,48 +1,124 @@
 import type { NitroRouteConfig } from 'nitropack';
 
+/** CMS page slugs that 301 elsewhere — omit from sitemap to avoid duplicate signals. */
+export const SITEMAP_EXCLUDED_PAGE_PATHS = new Set([
+  '/les-epices-essentielles-en-cuisine-1',
+]);
+
 const listRedirects: Record<string, NitroRouteConfig> = {
-  "/techniques-de-cuisine/**": {
-    redirect: { to: "/techniques-culinaires/**", statusCode: 301 },
+  '/sitemap-pages.xml': {
+    redirect: { to: '/__sitemap__/pages.xml', statusCode: 301 },
   },
-  "/techniques-de-culinaires/techniques-de-cuisson": {
-    redirect: { to: "/techniques-culinaires/methodes-de-cuisson", statusCode: 301 },
+  '/sitemap-blog.xml': {
+    redirect: { to: '/__sitemap__/blog.xml', statusCode: 301 },
   },
-  "/bases-culinaires/techniques-de-cuisson": {
-    redirect: { to: "/techniques-culinaires/methodes-de-cuisson", statusCode: 301 },
+  '/sitemap-recipes.xml': {
+    redirect: { to: '/__sitemap__/recipes.xml', statusCode: 301 },
   },
-  "/recipe/tout-sur-le-the-indien": {
-    redirect: { to: "/blog/tout-sur-le-the-indien", statusCode: 301 },
+
+  '/techniques-de-cuisine/**': {
+    redirect: { to: '/techniques-culinaires/**', statusCode: 301 },
   },
-  "/articles/tout-sur-le-the-indien": {
-    redirect: { to: "/blog/tout-sur-le-the-indien", statusCode: 301 },
+  '/techniques-de-culinaires/techniques-de-cuisson': {
+    redirect: { to: '/techniques-culinaires/methodes-de-cuisson', statusCode: 301 },
   },
-  "/articles/le-roi-du-riz-tout-ceque-vous-devez-savoir-sur-le-riz-basmati": {
+  '/bases-culinaires/techniques-de-cuisson': {
+    redirect: { to: '/techniques-culinaires/methodes-de-cuisson', statusCode: 301 },
+  },
+  '/bases-culinaires/**': {
+    redirect: { to: '/techniques-culinaires/**', statusCode: 301 },
+  },
+
+  '/les-epices-essentielles-en-cuisine-1': {
     redirect: {
-      to: "/blog/le-roi-du-riz-tout-ceque-vous-devez-savoir-sur-le-riz-basmati",
+      to: '/techniques-culinaires/les-epices-essentielles-en-cuisine',
       statusCode: 301,
     },
   },
-  "/articles/les-legumes-de-base-de-la-cuisine-asiatique": {
+
+  '/blog/astuces-de-cuisine/epices-indiennes-decouvrez-la-magie-des-saveurs-de-l-inde': {
     redirect: {
-      to: "/blog/les-legumes-de-base-de-la-cuisine-asiatique",
+      to: '/blog/astuces-de-cuisine/comment-utiliser-les-epices-et-les-herbes-aromatiques',
       statusCode: 301,
     },
   },
-  "/recette/les-legumes-de-base-de-la-cuisine-asiatique": {
+  '/blog/cuisine-sante/les-legumes-de-base-de-la-cuisine-asiatique': {
     redirect: {
-      to: "/blog/les-legumes-de-base-de-la-cuisine-asiatique",
+      to: '/blog/inspiration-culinaire/10-plats-de-street-food-asiatique-incontournables-a-faire-chez-soi',
       statusCode: 301,
     },
   },
-  "/recette/les-sauces-indispensables-pour-la-cuisine-asiatique": {
+  '/blog/guides-gourmands/les-meilleurs-restaurants-de-plats-de-street-food-asiatique-a-paris': {
     redirect: {
-      to: "/blog/les-sauces-indispensables-pour-la-cuisine-asiatique",
+      to: '/blog/guides-gourmands/ou-trouver-les-meilleures-brochettes-de-poulet-yakitori-a-paris',
       statusCode: 301,
     },
   },
-  "/recette/le-roi-du-riz-tout-ceque-vous-devez-savoir-sur-le-riz-basmati": {
+
+  '/recipe/tout-sur-le-the-indien': {
     redirect: {
-      to: "/blog/le-roi-du-riz-tout-ceque-vous-devez-savoir-sur-le-riz-basmati",
+      to: '/blog/astuces-de-cuisine/comment-utiliser-les-epices-et-les-herbes-aromatiques',
+      statusCode: 301,
+    },
+  },
+  '/articles/tout-sur-le-the-indien': {
+    redirect: {
+      to: '/blog/astuces-de-cuisine/comment-utiliser-les-epices-et-les-herbes-aromatiques',
+      statusCode: 301,
+    },
+  },
+  '/articles/le-roi-du-riz-tout-ceque-vous-devez-savoir-sur-le-riz-basmati': {
+    redirect: {
+      to: '/blog/cuisine-sante/tout-savoir-sur-le-clou-de-girofle',
+      statusCode: 301,
+    },
+  },
+  '/articles/les-legumes-de-base-de-la-cuisine-asiatique': {
+    redirect: {
+      to: '/blog/inspiration-culinaire/10-plats-de-street-food-asiatique-incontournables-a-faire-chez-soi',
+      statusCode: 301,
+    },
+  },
+  '/recette/les-legumes-de-base-de-la-cuisine-asiatique': {
+    redirect: {
+      to: '/blog/inspiration-culinaire/10-plats-de-street-food-asiatique-incontournables-a-faire-chez-soi',
+      statusCode: 301,
+    },
+  },
+  '/recette/les-sauces-indispensables-pour-la-cuisine-asiatique': {
+    redirect: {
+      to: '/blog/gastronomie-culture/ingredient-secret-de-la-cuisine-de-rue-asiatique-populaire-le-nuoc-mam',
+      statusCode: 301,
+    },
+  },
+  '/recette/le-roi-du-riz-tout-ceque-vous-devez-savoir-sur-le-riz-basmati': {
+    redirect: {
+      to: '/blog/cuisine-sante/tout-savoir-sur-le-clou-de-girofle',
+      statusCode: 301,
+    },
+  },
+
+  '/blog/tout-sur-le-the-indien': {
+    redirect: {
+      to: '/blog/astuces-de-cuisine/comment-utiliser-les-epices-et-les-herbes-aromatiques',
+      statusCode: 301,
+    },
+  },
+  '/blog/le-roi-du-riz-tout-ceque-vous-devez-savoir-sur-le-riz-basmati': {
+    redirect: {
+      to: '/blog/cuisine-sante/tout-savoir-sur-le-clou-de-girofle',
+      statusCode: 301,
+    },
+  },
+  '/blog/les-legumes-de-base-de-la-cuisine-asiatique': {
+    redirect: {
+      to: '/blog/inspiration-culinaire/10-plats-de-street-food-asiatique-incontournables-a-faire-chez-soi',
+      statusCode: 301,
+    },
+  },
+  '/blog/les-sauces-indispensables-pour-la-cuisine-asiatique': {
+    redirect: {
+      to: '/blog/gastronomie-culture/ingredient-secret-de-la-cuisine-de-rue-asiatique-populaire-le-nuoc-mam',
       statusCode: 301,
     },
   },

--- a/apps/web/app/utils/redirect.ts
+++ b/apps/web/app/utils/redirect.ts
@@ -7,6 +7,9 @@ const listRedirects: Record<string, NitroRouteConfig> = {
   "/techniques-de-culinaires/techniques-de-cuisson": {
     redirect: { to: "/techniques-culinaires/methodes-de-cuisson", statusCode: 301 },
   },
+  "/bases-culinaires/techniques-de-cuisson": {
+    redirect: { to: "/techniques-culinaires/methodes-de-cuisson", statusCode: 301 },
+  },
   "/recipe/tout-sur-le-the-indien": {
     redirect: { to: "/blog/tout-sur-le-the-indien", statusCode: 301 },
   },

--- a/apps/web/app/utils/sanitize-markdown.ts
+++ b/apps/web/app/utils/sanitize-markdown.ts
@@ -10,14 +10,19 @@ export function sanitizePublicMarkdown(markdown: string): string {
   output = output.replace(/\/blog\/undefined(?=[/"'\s)>]|$)/g, "/blog/uncategorized");
 
   output = output.replace(
-    /\/uploads\/[^"'()\s]*undefinedundefined/g,
-    "",
-  );
+    /!\[[^\]]*]\([^)]*undefinedundefined[^)]*\)/g,
+    '',
+  )
 
   output = output.replace(
-    /\/images\/[^"'()\s]*undefinedundefined/g,
-    "",
-  );
+    /\/uploads\/[^"'()\s]*undefinedundefined[^"'()\s]*/g,
+    '',
+  )
+
+  output = output.replace(
+    /\/images\/[^"'()\s]*undefinedundefined[^"'()\s]*/g,
+    '',
+  )
 
   return output;
 }

--- a/apps/web/app/utils/sanitize-markdown.ts
+++ b/apps/web/app/utils/sanitize-markdown.ts
@@ -1,0 +1,23 @@
+/** Fix common migration artifacts in CMS markdown before Comark render. */
+export function sanitizePublicMarkdown(markdown: string): string {
+  if (!markdown) {
+    return markdown;
+  }
+
+  let output = markdown;
+
+  output = output.replaceAll("/blog/undefined/", "/blog/uncategorized/");
+  output = output.replace(/\/blog\/undefined(?=[/"'\s)>]|$)/g, "/blog/uncategorized");
+
+  output = output.replace(
+    /\/uploads\/[^"'()\s]*undefinedundefined/g,
+    "",
+  );
+
+  output = output.replace(
+    /\/images\/[^"'()\s]*undefinedundefined/g,
+    "",
+  );
+
+  return output;
+}

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -8,8 +8,12 @@ const webRoot = fileURLToPath(new URL(".", import.meta.url));
 
 const skewProtectionKvNamespaceId =
   process.env.SKEW_PROTECTION_KV_NAMESPACE_ID || "skew-protection-local";
-/** Build-time KV uploads need Wrangler + API token; skip locally so `pnpm build` works offline. */
-const skewProtectionBundleAssets = Boolean(process.env.CLOUDFLARE_API_TOKEN);
+/** KV asset bundling only on deploy builds (real namespace + token), not local defaults. */
+const skewProtectionBundleAssets = Boolean(
+  process.env.CLOUDFLARE_API_TOKEN
+  && process.env.SKEW_PROTECTION_KV_NAMESPACE_ID
+  && skewProtectionKvNamespaceId !== "skew-protection-local",
+);
 
 const siteUrl = process.env.NUXT_PUBLIC_SITE_URL || "https://journalducuistot.fr";
 const siteOrigin = siteUrl.replace(/\/$/, "");

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -8,6 +8,8 @@ const webRoot = fileURLToPath(new URL(".", import.meta.url));
 
 const skewProtectionKvNamespaceId =
   process.env.SKEW_PROTECTION_KV_NAMESPACE_ID || "skew-protection-local";
+/** Build-time KV uploads need Wrangler + API token; skip locally so `pnpm build` works offline. */
+const skewProtectionBundleAssets = Boolean(process.env.CLOUDFLARE_API_TOKEN);
 
 const siteUrl = process.env.NUXT_PUBLIC_SITE_URL || "https://journalducuistot.fr";
 const siteOrigin = siteUrl.replace(/\/$/, "");
@@ -212,6 +214,7 @@ export default defineNuxtConfig({
 
   skewProtection: {
     updateStrategy: "polling",
+    bundleAssets: skewProtectionBundleAssets,
     storage: {
       driver: "cloudflare-kv-binding",
       binding: "SKEW_PROTECTION",

--- a/apps/web/server/api/__sitemap__/urls.ts
+++ b/apps/web/server/api/__sitemap__/urls.ts
@@ -1,6 +1,7 @@
 import { defineSitemapEventHandler } from "#imports";
 import type { SitemapUrlInput } from "#sitemap/types";
 import { generateSlug } from "~/utils/format";
+import { SITEMAP_EXCLUDED_PAGE_PATHS } from "~/utils/redirect";
 import type { Article, Page, Recipe } from "~/types/strapiMeta";
 import { serverCmsFindAll } from "../../utils/sitemap-cms";
 
@@ -32,8 +33,12 @@ export default defineSitemapEventHandler(async (): Promise<SitemapUrlInput[]> =>
   ];
 
   for (const doc of pages) {
+    const loc = generateSlug(doc.slug ?? "", doc.parent);
+    if (SITEMAP_EXCLUDED_PAGE_PATHS.has(loc)) {
+      continue;
+    }
     urls.push({
-      loc: generateSlug(doc.slug ?? "", doc.parent),
+      loc,
       lastmod: toSitemapLastmod(doc.updatedAt),
       priority: 0.8,
       changefreq: "daily",

--- a/apps/web/server/routes/blog/[slug].ts
+++ b/apps/web/server/routes/blog/[slug].ts
@@ -22,10 +22,8 @@ export default defineEventHandler(async (event) => {
 
     if (response.data && response.data.length > 0) {
       const articleData = response.data[0];
-      const category = articleData?.category;
-      if (category && category.slug) {
-        return sendRedirect(event, `/blog/${category.slug}/${articleSlug}`, 301);
-      }
+      const categorySlug = articleData?.category?.slug?.trim() || "uncategorized";
+      return sendRedirect(event, `/blog/${categorySlug}/${articleSlug}`, 301);
     }
 
     throw createError({

--- a/infra/workers.ts
+++ b/infra/workers.ts
@@ -49,9 +49,13 @@ export const workers = Effect.fn(function* (input: {
     },
   })
 
-  // AI Gateway + Workers AI binding (env.AI). Gateway id must match app `CMS_AI_GATEWAY_ID`.
-  const CmsAi = yield* Cloudflare.AI.Gateway('CmsAi', {
+  // Provision AI Gateway (dashboard logs, caching, rate limits).
+  // Nuxt CMS uses Workers AI binding + `CMS_AI_GATEWAY_ID` in `workers-ai-provider` (not Effect `QueryGateway`).
+  // @see https://alchemy.run/cloudflare/ai/ai-gateway/
+  // @see https://alchemy.run/cloudflare/ai/workers-ai
+  yield* Cloudflare.AI.Gateway('CmsAi', {
     id: CMS_AI_GATEWAY_ID,
+    cacheTtl: 60,
     collectLogs: true,
   })
 
@@ -74,7 +78,7 @@ export const workers = Effect.fn(function* (input: {
       DB: input.DB,
       Media: input.Media,
       Cache: input.Cache,
-      AI: CmsAi,
+      AI: Cloudflare.Workers.AI(),
       CMS_AI_GATEWAY_ID: Config.string('CMS_AI_GATEWAY_ID').pipe(
         Config.withDefault(CMS_AI_GATEWAY_ID),
       ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-powered editor reviews for continuing, reformulating, and proofreading content.
  * Reformulation now offers two alternatives, with highlighted changes and accept, reject, or redo controls.
  * Added French proofreading suggestions with individual correction decisions.
  * Added clearer loading states and inline completion suggestions.

* **Bug Fixes**
  * Improved article URLs, redirects, navigation, sitemap exclusions, and missing-category handling.
  * Sanitized rendered markdown to prevent malformed links and images.
  * Improved social metadata dates and preview error responses.
  * Added related-content sections to recipe pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large editor and completion refactor plus infra AI binding changes can affect all CMS authoring; public URL and redirect updates affect SEO and inbound links but are mostly additive fixes.
> 
> **Overview**
> **CMS markdown editor** no longer auto-applies AI transforms. Continuer, reformulations, and Orthographe stream into a floating **review panel** (accept / refuse / relancer) with two variants for rewrite modes and per-correction toggles for French proofreading. Ghost **Mod-j / Tab** completion stays separate; toolbar “Continuer” uses the review flow. TipTap gets highlight decorations and CSS for review states; `POST /api/proofread` plus shared sanitization limit bogus LLM spans.
> 
> **Workers AI plumbing** picks Gemma vs Llama by mode, strips reasoning from visible output, buffers completions in dev, streams via Node `Readable` in prod, and wires remote AI in dev through generated `.wrangler/dev/wrangler.json`. Infra binds `Cloudflare.Workers.AI()` instead of routing the gateway object as the binding.
> 
> **Public site (`apps/web`)** standardizes article URLs with an `uncategorized` fallback, expands 301 redirects and legacy sitemap aliases, sanitizes broken migration markdown links/images, tightens OG dates and prev/next nav, and drops empty prev/next on recipes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4000094d5667e3d1297dcd4faf8d37369811243f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->