### PR TITLE
Dev

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Nuxt UI Templates
+Copyright (c) 2026 Bertyn Boulikou
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -6,7 +6,6 @@
  */
 import * as Alchemy from 'alchemy'
 import * as Cloudflare from 'alchemy/Cloudflare'
-import * as Command from 'alchemy/Command'
 import * as Drizzle from 'alchemy/Drizzle'
 import * as Effect from 'effect/Effect'
 import * as Layer from 'effect/Layer'
@@ -28,7 +27,6 @@ export default Alchemy.Stack(
     providers: Layer.mergeAll(
       Cloudflare.providers(),
       Drizzle.providers(),
-      Command.providers(),
     ),
     state: useRemoteState ? Cloudflare.state() : Alchemy.localState(),
   },

--- a/apps/cms/AGENTS.md
+++ b/apps/cms/AGENTS.md
@@ -7,7 +7,7 @@
 1. **French admin UI** — Nuxt UI dashboard for content, media, planning, Strapi import, and maintenance.
 2. **REST API** under `/api/*` — consumed by `apps/web` and by the admin itself.
 
-Persistence: **Drizzle ORM** on SQLite (local libSQL at `.data/db/sqlite.db` in dev; **Cloudflare D1** in production via Nitro `cloudflare_module` preset). Media: **R2** (local bucket binding in dev). Sessions: **nuxt-auth-utils** (sealed cookie, 8h max age). Authorization: **nuxt-authorization** with roles `admin` | `editor` (`shared/abilities.ts`).
+Persistence: **Drizzle ORM** on SQLite (local libSQL at `.data/db/sqlite.db` in dev; **Cloudflare D1** in production via Alchemy `Website.Nuxt`). Media: **R2** (local bucket binding in dev). Sessions: **nuxt-auth-utils** (sealed cookie, 8h max age). Authorization: **nuxt-authorization** with roles `admin` | `editor` (`shared/abilities.ts`).
 
 Replaces Strapi v5 as the system of record; Strapi remains a **migration source** via the import UI and extract services.
 

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -45,10 +45,10 @@ pnpm task:strapi-extract
 | Path | Database | Migrations |
 |------|----------|------------|
 | `pnpm dev:cms` | `.data/db/sqlite.db` (libSQL) | `scripts/migrate-local.ts` before Nuxt |
-| `pnpm dev:infra` (repo root) | Alchemy dev worker + bindings | Use CMS URL from Alchemy (not only `:3001`) for Workers AI |
+| `pnpm dev:infra` (repo root) | Alchemy local D1 + bindings via `Website.Nuxt` | D1 migrations from Alchemy; Nuxt HMR + `event.context.cloudflare` (wrangler-free) |
 | `pnpm alchemy deploy` (repo root) | Cloudflare D1 | Drizzle migrations in `server/db/migrations/sqlite/` |
 
-**Editor AI (`POST /api/completion`)** needs the Workers AI binding (`env.AI`). Bindings live in `nuxt.config.ts` (`nitro.cloudflare.wrangler`); dev writes `.wrangler/dev/wrangler.json` for Wrangler `getPlatformProxy`. Requires `wrangler` (repo devDependency) and Cloudflare auth. Alchemy: `Cloudflare.AI.Gateway` + `Cloudflare.Workers.AI()` in `infra/workers.ts` — redeploy after infra changes.
+**Editor AI (`POST /api/completion`)** needs the Workers AI binding (`env.AI`). Prefer `pnpm dev:infra` so Alchemy serves the binding. Standalone `pnpm dev:cms` still writes `.wrangler/dev/wrangler.json` for Wrangler `getPlatformProxy`. Alchemy: `Cloudflare.Website.Nuxt` + `Cloudflare.AI.Gateway` + `Cloudflare.Workers.AI()` in `infra/workers.ts` — redeploy after infra changes.
 
 ## Admin seeder
 

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -8,7 +8,7 @@ Custom CMS for [Journal du Cuistot](https://journalducuistot.fr): **Nuxt admin d
 
 | Layer | Choice |
 |-------|--------|
-| Framework | Nuxt 4 (`compatibilityVersion: 5`), Nitro `cloudflare_module` |
+| Framework | Nuxt 4 (`compatibilityVersion: 5`), Cloudflare deployment via Alchemy `Website.Nuxt` |
 | Admin UI | Nuxt UI 4 dashboard (French) |
 | ORM / DB | Drizzle → SQLite (local libSQL) / Cloudflare D1 (prod) |
 | Media | R2 (+ local binding in dev) |
@@ -48,7 +48,7 @@ pnpm task:strapi-extract
 | `pnpm dev:infra` (repo root) | Alchemy local D1 + bindings via `Website.Nuxt` | D1 migrations from Alchemy; Nuxt HMR + `event.context.cloudflare` (wrangler-free) |
 | `pnpm alchemy deploy` (repo root) | Cloudflare D1 | Drizzle migrations in `server/db/migrations/sqlite/` |
 
-**Editor AI (`POST /api/completion`)** needs the Workers AI binding (`env.AI`). Prefer `pnpm dev:infra` so Alchemy serves the binding. Standalone `pnpm dev:cms` still writes `.wrangler/dev/wrangler.json` for Wrangler `getPlatformProxy`. Alchemy: `Cloudflare.Website.Nuxt` + `Cloudflare.AI.Gateway` + `Cloudflare.Workers.AI()` in `infra/workers.ts` — redeploy after infra changes.
+**Editor AI (`POST /api/completion`)** needs the Workers AI binding (`env.AI`). Use `pnpm dev:infra` for Alchemy's wrangler-free local binding proxy; standalone `pnpm dev:cms` uses the local database and the generation fallback without Cloudflare bindings. Alchemy: `Cloudflare.Website.Nuxt` + `Cloudflare.AI.Gateway` + `Cloudflare.Workers.AI()` in `infra/workers.ts` — redeploy after infra changes.
 
 ## Admin seeder
 

--- a/apps/cms/app/error.vue
+++ b/apps/cms/app/error.vue
@@ -1,18 +1,25 @@
 <script setup lang="ts">
 import type { NuxtError } from '#app'
+import { computed } from 'vue'
+import { getErrorCode } from '../shared/error-code'
 
-defineProps<{
+const props = defineProps<{
   error: NuxtError
 }>()
 
+const errorCode = computed(() => getErrorCode(props.error))
+
 useSeoMeta({
   title: 'Erreur',
-  description: 'Une erreur est survenue.'
+  description: 'Une erreur est survenue.',
 })
 </script>
 
 <template>
   <UApp>
     <UError :error="error" />
+    <p v-if="errorCode" class="mt-3 text-center text-sm text-muted">
+      Code d’erreur : {{ errorCode }}
+    </p>
   </UApp>
 </template>

--- a/apps/cms/app/plugins/evlog-errors.client.ts
+++ b/apps/cms/app/plugins/evlog-errors.client.ts
@@ -1,0 +1,69 @@
+import { log } from 'evlog/client'
+import { getErrorCode } from '../../shared/error-code'
+
+type NuxtClientError = {
+  code?: string
+  docs?: string
+  fix?: string
+  name?: string
+  message?: string
+  stack?: string
+  why?: string
+}
+
+const reportedErrors = new WeakSet<object>()
+
+function serializeError(error: unknown): NuxtClientError {
+  const record = error && typeof error === 'object' ? (error as Record<string, unknown>) : undefined
+  const serialized: NuxtClientError = {
+    ...(typeof record?.code === 'string' ? { code: record.code } : {}),
+    ...(typeof record?.docs === 'string' ? { docs: record.docs } : {}),
+    ...(typeof record?.fix === 'string' ? { fix: record.fix } : {}),
+    ...(typeof record?.name === 'string' ? { name: record.name } : {}),
+    ...(typeof record?.message === 'string' ? { message: record.message } : {}),
+    ...(typeof record?.stack === 'string' ? { stack: record.stack } : {}),
+    ...(typeof record?.why === 'string' ? { why: record.why } : {}),
+  }
+
+  const code = getErrorCode(error)
+  if (code) serialized.code = code
+
+  if (Object.keys(serialized).length > 0) {
+    return serialized
+  }
+  return { message: String(error) }
+}
+
+function reportError(error: unknown, context: Record<string, string>) {
+  if (error && typeof error === 'object') {
+    if (reportedErrors.has(error)) {
+      return
+    }
+    reportedErrors.add(error)
+  }
+
+  const serializedError = serializeError(error)
+  log.error({
+    source: 'nuxt-client',
+    ...context,
+    ...(typeof serializedError.code === 'string' ? { errorCode: serializedError.code } : {}),
+    error: serializedError,
+  })
+}
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hook('vue:error', (error, _instance, info) => {
+    reportError(error, {
+      framework: 'vue',
+      hook: 'vue:error',
+      info,
+    })
+  })
+
+  nuxtApp.hook('app:error', (error) => {
+    reportError(error, {
+      framework: 'nuxt',
+      hook: 'app:error',
+    })
+  })
+})

--- a/apps/cms/exports.cloudflare.ts
+++ b/apps/cms/exports.cloudflare.ts
@@ -2,6 +2,10 @@
  * Extra Cloudflare Worker exports for Nitro (`cloudflare_module`).
  * Must not have a default export.
  *
+ * Auto-detected by Nitro and included in the Alchemy `Website.Nuxt` Worker
+ * entry (no custom `main` required).
+ *
  * @see https://nitro.build/deploy/providers/cloudflare#additional-exports
+ * @see https://alchemy.run/cloudflare/frontend/nuxt/
  */
 export { ContentGenerationWorkflow } from './server/workflows/content-generation'

--- a/apps/cms/nuxt.config.ts
+++ b/apps/cms/nuxt.config.ts
@@ -4,11 +4,11 @@ export default defineNuxtConfig({
     port: 3001,
   },
 
-  modules: ['nuxt-auth-utils', 'nuxt-authorization', '@nuxt/ui', '@vueuse/nuxt', 'evlog'],
+  modules: ['nuxt-auth-utils', 'nuxt-authorization', '@nuxt/ui', '@vueuse/nuxt', 'evlog/nuxt'],
 
   runtimeConfig: {
     public: {
-      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'https://journalducuistot.fr',
+      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'http://localhost:3000',
     },
     session: {
       maxAge: 60 * 60 * 8,
@@ -84,5 +84,22 @@ export default defineNuxtConfig({
       service: 'journalducuistot-cms',
     },
     include: ['/api/**'],
+    exclude: ['/api/_evlog/ingest'],
+    redact: {
+      paths: [
+        'user.email',
+        'headers.authorization',
+        'headers.cookie',
+        'request.headers.authorization',
+        'request.headers.cookie',
+      ],
+    },
+    strip: ['debug'],
+    sourceLocation: 'dev',
+    transport: {
+      enabled: true,
+      endpoint: '/api/_evlog/ingest',
+      credentials: 'include',
+    },
   },
 })

--- a/apps/cms/nuxt.config.ts
+++ b/apps/cms/nuxt.config.ts
@@ -1,46 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-import { mkdirSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
-
-function writeDevWranglerConfig(nitroConfig: {
-  dev?: boolean
-  rootDir?: string
-  compatibilityDate?: { cloudflare?: string, default?: string }
-  cloudflare?: { deployConfig?: boolean, wrangler?: Record<string, unknown> }
-}) {
-  if (!nitroConfig.dev || !nitroConfig.cloudflare?.deployConfig || !nitroConfig.rootDir) {
-    return
-  }
-  const wrangler = { ...(nitroConfig.cloudflare.wrangler ?? {}) }
-  // Workflows need a deployed `script_name`; omit them in local getPlatformProxy
-  // to avoid Wrangler’s noisy “not available in local development” warning.
-  delete wrangler.workflows
-  const devWrangler = {
-    ...wrangler,
-    name: 'jdc-cms-local',
-    compatibility_date:
-      nitroConfig.compatibilityDate?.cloudflare
-      ?? nitroConfig.compatibilityDate?.default
-      ?? '2026-05-27',
-  }
-  const dir = join(nitroConfig.rootDir, '.wrangler/dev')
-  const path = join(dir, 'wrangler.json')
-  mkdirSync(dir, { recursive: true })
-  writeFileSync(path, JSON.stringify(devWrangler, null, 2))
-}
-
 export default defineNuxtConfig({
   devServer: {
-    port: 3001
+    port: 3001,
   },
 
-  modules: [
-    'nuxt-auth-utils',
-    'nuxt-authorization',
-    '@nuxt/ui',
-    '@vueuse/nuxt',
-    'evlog',
-  ],
+  modules: ['nuxt-auth-utils', 'nuxt-authorization', '@nuxt/ui', '@vueuse/nuxt', 'evlog'],
 
   runtimeConfig: {
     public: {
@@ -53,7 +17,8 @@ export default defineNuxtConfig({
     strapiUrl: process.env.NUXT_STRAPI_URL || process.env.STRAPI_URL || '',
     strapiApiToken: process.env.NUXT_STRAPI_API_TOKEN || process.env.STRAPI_API_TOKEN || '',
     /** Optional origin for Strapi `/uploads` files (e.g. public site CDN). */
-    strapiUploadsOrigin: process.env.NUXT_STRAPI_UPLOADS_ORIGIN || process.env.STRAPI_UPLOADS_ORIGIN || '',
+    strapiUploadsOrigin:
+      process.env.NUXT_STRAPI_UPLOADS_ORIGIN || process.env.STRAPI_UPLOADS_ORIGIN || '',
     /** Nuxt SEO Pro MCP (in-app content agent keyword tools). */
     nuxtSeoProMcpUrl: process.env.NUXT_SEO_PRO_MCP_URL || 'https://nuxtseo.com/mcp/pro',
     nuxtSeoProApiKey: process.env.NUXT_SEO_PRO_API_KEY || '',
@@ -64,7 +29,7 @@ export default defineNuxtConfig({
   css: ['~/assets/css/main.css'],
 
   devtools: {
-    enabled: true
+    enabled: true,
   },
 
   vite: {
@@ -82,76 +47,25 @@ export default defineNuxtConfig({
   },
 
   future: {
-    compatibilityVersion: 5
+    compatibilityVersion: 5,
   },
 
   nitro: {
-    // Same preset Alchemy Website.Nuxt enforces — keep for standalone `pnpm build` /
-    // `nuxt preview`. A *different* preset would hard-error under Alchemy.
-    preset: 'cloudflare_module',
-    compatibilityDate: '2026-05-27',
-    cloudflare: {
-      // Alchemy Website.Nuxt forces deployConfig:false (wrangler-free). This
-      // wrangler block is only for standalone `pnpm dev:cms` getPlatformProxy.
-      deployConfig: true,
-      dev: {
-        // Generated on dev start from `cloudflare.wrangler` below (bindings-only for getPlatformProxy).
-        configPath: '.wrangler/dev/wrangler.json',
-      },
-      wrangler: {
-        compatibility_flags: ['nodejs_compat'],
-        d1_databases: [
-          {
-            binding: 'DB',
-            database_name: 'cms-local',
-            database_id: 'cms-local',
-          },
-        ],
-        r2_buckets: [
-          {
-            binding: 'Media',
-            bucket_name: 'cms-media-local',
-          },
-        ],
-        kv_namespaces: [
-          {
-            binding: 'Cache',
-            id: 'cms-cache-local',
-          },
-        ],
-        ai: {
-          binding: 'AI',
-          remote: true,
-        },
-        workflows: [
-          {
-            name: 'content-generation',
-            binding: 'CONTENT_GENERATION',
-            class_name: 'ContentGenerationWorkflow',
-          },
-        ],
-      },
-    },
     experimental: {
       tasks: true,
       asyncContext: true,
     },
     ...(process.env.NODE_ENV === 'production'
       ? {
-        scheduledTasks: {
-          '*/5 * * * *': 'publish-scheduled',
-          // Fallback poller if Workflow create failed / local legacy runs.
-          '2-57/5 * * * *': 'generation-process',
-        },
-      }
+          scheduledTasks: {
+            '*/5 * * * *': 'publish-scheduled',
+            // Fallback poller if Workflow create failed / local legacy runs.
+            '2-57/5 * * * *': 'generation-process',
+          },
+        }
       : {}),
     externals: {
-      inline: [
-        '@jsquash/jpeg',
-        '@jsquash/png',
-        '@jsquash/webp',
-        '@jsquash/resize',
-      ],
+      inline: ['@jsquash/jpeg', '@jsquash/png', '@jsquash/webp', '@jsquash/resize'],
     },
   },
 
@@ -170,11 +84,5 @@ export default defineNuxtConfig({
       service: 'journalducuistot-cms',
     },
     include: ['/api/**'],
-  },
-
-  hooks: {
-    'nitro:config'(nitroConfig) {
-      writeDevWranglerConfig(nitroConfig)
-    },
   },
 })

--- a/apps/cms/nuxt.config.ts
+++ b/apps/cms/nuxt.config.ts
@@ -86,9 +86,13 @@ export default defineNuxtConfig({
   },
 
   nitro: {
+    // Same preset Alchemy Website.Nuxt enforces — keep for standalone `pnpm build` /
+    // `nuxt preview`. A *different* preset would hard-error under Alchemy.
     preset: 'cloudflare_module',
     compatibilityDate: '2026-05-27',
     cloudflare: {
+      // Alchemy Website.Nuxt forces deployConfig:false (wrangler-free). This
+      // wrangler block is only for standalone `pnpm dev:cms` getPlatformProxy.
       deployConfig: true,
       dev: {
         // Generated on dev start from `cloudflare.wrangler` below (bindings-only for getPlatformProxy).

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cms",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "nuxt build",
-    "dev": "node --import tsx scripts/migrate-local.ts && nuxt dev",
+    "dev": "alchemy dev",
+    "deploy": "alchemy deploy",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "lint": "oxlint .",

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260712.1",
+    "@distilled.cloud/nuxt": "^0.17.1",
     "@nuxt/eslint-plugin": "catalog:",
     "@vitest/browser-playwright": "^4.1.6",
     "@vitest/coverage-v8": "^4.1.6",

--- a/apps/cms/scripts/hydrate-strapi-media.ts
+++ b/apps/cms/scripts/hydrate-strapi-media.ts
@@ -64,7 +64,10 @@ async function main() {
   loadEnvFile(resolve(root, '../../.env'))
 
   const { dryRun, slug, delayMs } = parseArgs(process.argv.slice(2))
-  const strapiUrl = process.env.STRAPI_URL || 'https://admin.journalducuistot.fr'
+  const strapiUrl = process.env.STRAPI_URL
+  if (!strapiUrl?.trim()) {
+    throw new Error('STRAPI_URL is required for media hydration')
+  }
   const strapiApiToken = process.env.STRAPI_API_TOKEN || undefined
   const strapiUploadsOrigin = process.env.STRAPI_UPLOADS_ORIGIN || undefined
 

--- a/apps/cms/server/api/admin/users/[id].patch.ts
+++ b/apps/cms/server/api/admin/users/[id].patch.ts
@@ -1,3 +1,4 @@
+import { useLogger } from 'evlog'
 import { updateStaffUserSchema } from '../../../../shared/validators/staff'
 import { requireAdmin } from '../../../utils/http-auth'
 import { createApiError } from '../../../utils/errors'
@@ -13,14 +14,10 @@ export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const parsed = updateStaffUserSchema.safeParse(body)
   if (!parsed.success) {
-    throw createApiError(
-      'VALIDATION_ERROR',
-      'Mise à jour invalide.',
-      parsed.error.flatten(),
-    )
+    throw createApiError('VALIDATION_ERROR', 'Mise à jour invalide.', parsed.error.flatten())
   }
 
-  const log = useLogger(event)
+  const log = useLogger(event as Parameters<typeof useLogger>[0])
   const data = await useStaffService(event).update(id, session.user!.id, parsed.data)
   log.set({ staff: { action: 'update', targetUserId: id, patch: parsed.data } })
 

--- a/apps/cms/server/api/admin/users/index.post.ts
+++ b/apps/cms/server/api/admin/users/index.post.ts
@@ -1,3 +1,4 @@
+import { useLogger } from 'evlog'
 import { createStaffUserSchema } from '../../../../shared/validators/staff'
 import { requireAdmin } from '../../../utils/http-auth'
 import { createApiError } from '../../../utils/errors'
@@ -11,11 +12,11 @@ export default defineEventHandler(async (event) => {
     throw createApiError(
       'VALIDATION_ERROR',
       'Données utilisateur invalides.',
-      parsed.error.flatten(),
+      parsed.error.flatten()
     )
   }
 
-  const log = useLogger(event)
+  const log = useLogger(event as Parameters<typeof useLogger>[0])
   const user = await useStaffService(event).create(parsed.data)
   log.set({ staff: { action: 'create', targetUserId: user.id, role: user.role } })
 

--- a/apps/cms/server/api/auth/login.post.ts
+++ b/apps/cms/server/api/auth/login.post.ts
@@ -1,3 +1,4 @@
+import { useLogger } from 'evlog'
 import { loginSchema } from '../../../shared/validators/auth'
 import { toSessionUser } from '../../utils/auth/user'
 import { getClientIp } from '../../utils/client-ip'
@@ -13,8 +14,8 @@ const LOGIN_LIMIT = {
   windowSeconds: 15 * 60,
 } as const
 
-const DUMMY_HASH
-  = 'pbkdf2:100000:sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+const DUMMY_HASH =
+  'pbkdf2:100000:sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
 
 function getLoginLimiter(event: H3Event) {
   return createRateLimiter(useKvStore(event), LOGIN_LIMIT)
@@ -34,11 +35,9 @@ export default defineEventHandler(async (event) => {
 
   const status = await limiter.check(ip)
   if (status.blocked) {
-    throw createApiError(
-      'FORBIDDEN',
-      'Too many failed login attempts. Try again later.',
-      { retryAfterSeconds: 15 * 60 },
-    )
+    throw createApiError('FORBIDDEN', 'Too many failed login attempts. Try again later.', {
+      retryAfterSeconds: 15 * 60,
+    })
   }
 
   const user = await users.findByEmail(email)
@@ -46,8 +45,7 @@ export default defineEventHandler(async (event) => {
   let passwordOk = false
   if (user) {
     passwordOk = await verifyPassword(user.passwordHash, password)
-  }
-  else {
+  } else {
     await verifyPassword(DUMMY_HASH, password)
   }
 
@@ -57,17 +55,14 @@ export default defineEventHandler(async (event) => {
   }
 
   if (!user.isActive) {
-    throw createApiError(
-      'FORBIDDEN',
-      'Ce compte a été désactivé.',
-      undefined,
-      { fix: 'Contactez un administrateur.' },
-    )
+    throw createApiError('FORBIDDEN', 'Ce compte a été désactivé.', undefined, {
+      fix: 'Contactez un administrateur.',
+    })
   }
 
   await limiter.reset(ip)
 
-  const log = useLogger(event)
+  const log = useLogger(event as Parameters<typeof useLogger>[0])
   log.set({ auth: { action: 'login', userId: user.id, role: user.role } })
 
   const safeUser = toSessionUser(user)

--- a/apps/cms/server/api/completion.post.ts
+++ b/apps/cms/server/api/completion.post.ts
@@ -1,6 +1,7 @@
 import { generateText, streamText } from 'ai'
 import { Readable } from 'node:stream'
 import type { H3Event } from 'h3'
+import { useLogger } from 'evlog'
 import { z } from 'zod'
 import { EDITOR_COMPLETION_MODES } from '../../shared/editor-completion-modes'
 import {
@@ -19,6 +20,7 @@ import {
 import { createApiError } from '../utils/errors'
 import { requireEditor } from '../utils/http-auth'
 import { useKvStore } from '../utils/kv'
+import { toLogError } from '../utils/logging'
 import { createRequestRateLimiter } from '../utils/rate-limit'
 
 const COMPLETION_LIMIT = {
@@ -68,7 +70,7 @@ function sendPlainTextCompletionStream(event: H3Event, textStream: AsyncIterable
  * model never emits content tokens, fall back once to recovered answer text.
  */
 async function* streamVisibleEditorText(
-  result: ReturnType<typeof streamText>,
+  result: ReturnType<typeof streamText>
 ): AsyncGenerator<string> {
   let emitted = false
   for await (const chunk of result.textStream) {
@@ -82,10 +84,7 @@ async function* streamVisibleEditorText(
     return
   }
 
-  const [text, reasoningText] = await Promise.all([
-    result.text,
-    result.reasoningText,
-  ])
+  const [text, reasoningText] = await Promise.all([result.text, result.reasoningText])
   const visible = resolveVisibleCompletionText({ text, reasoningText })
   if (visible) {
     yield visible
@@ -93,16 +92,23 @@ async function* streamVisibleEditorText(
 }
 
 export default defineEventHandler(async (event) => {
+  const log = useLogger(event as Parameters<typeof useLogger>[0])
   const session = await requireEditor(event)
 
   const ip = getClientIp(event)
   const rateKey = `${session.user.id}:${ip}`
   const rate = await getCompletionLimiter(event).consume(rateKey)
   if (!rate.allowed) {
+    log.warn('Editor completion rate limit exceeded', {
+      completion: {
+        userId: session.user.id,
+        retryAfterSeconds: COMPLETION_LIMIT.windowSeconds,
+      },
+    })
     throw createApiError(
       'FORBIDDEN',
       'Trop de requêtes d’assistance IA. Réessayez dans une minute.',
-      { retryAfterSeconds: COMPLETION_LIMIT.windowSeconds },
+      { retryAfterSeconds: COMPLETION_LIMIT.windowSeconds }
     )
   }
 
@@ -112,27 +118,46 @@ export default defineEventHandler(async (event) => {
     throw createApiError(
       'VALIDATION_ERROR',
       'Requête d’assistance IA invalide.',
-      parsed.error.flatten(),
+      parsed.error.flatten()
     )
   }
 
   const env = getCloudflareEnv(event)
   if (!env?.AI) {
-    throw createError({
-      statusCode: 503,
-      statusMessage: 'Workers AI n’est pas configuré. Déployez via Alchemy ou activez le binding AI local.',
+    const cause = new Error('Workers AI binding is missing')
+    log.error(cause, {
+      completion: {
+        step: 'resolve-binding',
+        userId: session.user.id,
+      },
+    })
+    throw createApiError('INTERNAL_ERROR', 'Workers AI n’est pas configuré.', undefined, {
+      status: 503,
+      why: 'Le binding Workers AI est absent de cet environnement.',
+      fix: 'Déployez via Alchemy ou activez le binding AI local.',
+      cause,
+      internal: { binding: 'AI' },
     })
   }
 
   const mode = (parsed.data.mode ?? 'continue') as EditorCompletionMode
   const { system, maxOutputTokens, cacheTtl } = buildEditorCompletionConfig(
     mode,
-    parsed.data.language,
+    parsed.data.language
   )
   const prompt = truncateEditorPrompt(parsed.data.prompt)
   const gatewayId = resolveCompletionGatewayId(event, env.CMS_AI_GATEWAY_ID)
   const modelId = resolveEditorCompletionModelId(mode)
   const creative = isCreativeEditorCompletionMode(mode)
+
+  log.set({
+    completion: {
+      mode,
+      model: modelId,
+      userId: session.user.id,
+      ...(parsed.data.language ? { language: parsed.data.language } : {}),
+    },
+  })
 
   const workersai = createCmsWorkersAI(env.AI, {
     gatewayId,
@@ -185,31 +210,50 @@ export default defineEventHandler(async (event) => {
         reasoningText: generated.reasoningText,
       })
       if (!visible) {
-        console.error('[completion] empty Workers AI response', {
-          model: modelId,
-          mode,
-          finishReason: generated.finishReason,
-          usage: generated.usage,
-          textLen: generated.text?.length ?? 0,
-          reasoningLen: generated.reasoningText?.length ?? 0,
+        const cause = new Error('Workers AI returned an empty response')
+        log.error(cause, {
+          completion: {
+            step: 'generate-text',
+            finishReason: generated.finishReason,
+            outputLength: generated.text?.length ?? 0,
+            reasoningLength: generated.reasoningText?.length ?? 0,
+          },
         })
-        throw createError({
-          statusCode: 502,
-          message: 'Workers AI a renvoyé une réponse vide.',
-        })
+        throw createApiError(
+          'INTERNAL_ERROR',
+          'Workers AI a renvoyé une réponse vide.',
+          undefined,
+          {
+            status: 502,
+            why: 'Le modèle n’a produit aucun contenu exploitable.',
+            fix: 'Réessayez la génération ou choisissez un autre mode.',
+            cause,
+            internal: { model: modelId, mode },
+          }
+        )
       }
+      log.set({
+        completion: {
+          status: 'success',
+          finishReason: generated.finishReason,
+          outputLength: visible.length,
+        },
+      })
       setResponseHeader(event, 'Content-Type', 'text/plain; charset=utf-8')
       return visible
-    }
-    catch (error) {
+    } catch (error) {
       if (error && typeof error === 'object' && 'statusCode' in error) {
         throw error
       }
-      console.error('[completion] generateText failed', error)
-      throw createError({
-        statusCode: 502,
-        message: 'Échec de génération Workers AI.',
-        cause: error,
+      log.error(toLogError(error), {
+        completion: { step: 'generate-text' },
+      })
+      throw createApiError('INTERNAL_ERROR', 'Échec de génération Workers AI.', undefined, {
+        status: 502,
+        why: 'Le service Workers AI n’a pas pu générer le texte.',
+        fix: 'Réessayez dans quelques instants.',
+        cause: error instanceof Error ? error : undefined,
+        internal: { model: modelId, mode },
       })
     }
   }
@@ -217,7 +261,13 @@ export default defineEventHandler(async (event) => {
   const result = streamText({
     ...shared,
     onError: ({ error }) => {
-      console.error('[completion] streamText error', error)
+      log.error(toLogError(error), {
+        completion: {
+          step: 'stream-text',
+          model: modelId,
+          mode,
+        },
+      })
     },
   })
 

--- a/apps/cms/server/api/proofread.post.ts
+++ b/apps/cms/server/api/proofread.post.ts
@@ -1,3 +1,4 @@
+import { useLogger } from 'evlog'
 import { z } from 'zod'
 import { runEditorProofread } from '../services/ai/editor-proofread'
 import { getClientIp } from '../utils/client-ip'
@@ -5,6 +6,7 @@ import { getCloudflareEnv } from '../utils/cloudflare-env'
 import { createApiError } from '../utils/errors'
 import { requireEditor } from '../utils/http-auth'
 import { useKvStore } from '../utils/kv'
+import { toLogError } from '../utils/logging'
 import { createRequestRateLimiter } from '../utils/rate-limit'
 
 const LIMIT = {
@@ -18,15 +20,17 @@ const bodySchema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
+  const log = useLogger(event as Parameters<typeof useLogger>[0])
   const session = await requireEditor(event)
   const ip = getClientIp(event)
-  const rate = await createRequestRateLimiter(useKvStore(event), LIMIT)
-    .consume(`${session.user.id}:${ip}`)
+  const rate = await createRequestRateLimiter(useKvStore(event), LIMIT).consume(
+    `${session.user.id}:${ip}`
+  )
   if (!rate.allowed) {
     throw createApiError(
       'FORBIDDEN',
       'Trop de requêtes d’orthographe. Réessayez dans une minute.',
-      { retryAfterSeconds: LIMIT.windowSeconds },
+      { retryAfterSeconds: LIMIT.windowSeconds }
     )
   }
 
@@ -37,37 +41,58 @@ export default defineEventHandler(async (event) => {
 
   const env = getCloudflareEnv(event)
   if (!env?.AI) {
-    throw createApiError(
-      'INTERNAL_ERROR',
-      'Workers AI n’est pas configuré.',
-      undefined,
-      { why: 'Binding AI absent sur cet environnement.' },
-    )
+    const cause = new Error('Workers AI binding is missing')
+    log.error(cause, {
+      proofread: {
+        step: 'resolve-binding',
+        userId: session.user.id,
+      },
+    })
+    throw createApiError('INTERNAL_ERROR', 'Workers AI n’est pas configuré.', undefined, {
+      status: 503,
+      why: 'Le binding Workers AI est absent de cet environnement.',
+      fix: 'Déployez via Alchemy ou activez le binding AI local.',
+      cause,
+      internal: { binding: 'AI' },
+    })
   }
 
   const gatewayId = import.meta.dev
     ? null
-    : (env.CMS_AI_GATEWAY_ID
-      || (typeof useRuntimeConfig(event).cmsAiGatewayId === 'string'
-        ? useRuntimeConfig(event).cmsAiGatewayId as string
-        : null))
+    : env.CMS_AI_GATEWAY_ID ||
+      (typeof useRuntimeConfig(event).cmsAiGatewayId === 'string'
+        ? (useRuntimeConfig(event).cmsAiGatewayId as string)
+        : null)
+
+  log.set({
+    proofread: {
+      userId: session.user.id,
+      inputLength: parsed.data.text.length,
+      provider: 'workers-ai',
+    },
+  })
 
   try {
     const corrections = await runEditorProofread({
       ai: env.AI,
       text: parsed.data.text,
       gatewayId,
-      userId: session.user.id,
+      userId: String(session.user.id),
     })
     return { corrections }
-  }
-  catch (error) {
-    console.error('[proofread] failed', error)
-    throw createApiError(
-      'INTERNAL_ERROR',
-      'Échec de l’analyse orthographique.',
-      undefined,
-      { why: error instanceof Error ? error.message : 'Erreur inconnue' },
-    )
+  } catch (error) {
+    const cause = error instanceof Error ? error : new Error(String(toLogError(error)))
+    log.error(cause, {
+      proofread: {
+        step: 'run-editor-proofread',
+        inputLength: parsed.data.text.length,
+      },
+    })
+    throw createApiError('INTERNAL_ERROR', 'Échec de l’analyse orthographique.', undefined, {
+      status: 502,
+      why: 'Le service Workers AI n’a pas pu analyser le texte.',
+      fix: 'Réessayez dans quelques instants.',
+      cause,
+    })
   }
 })

--- a/apps/cms/server/plugins/evlog-enrich.ts
+++ b/apps/cms/server/plugins/evlog-enrich.ts
@@ -1,0 +1,7 @@
+import { createDefaultEnrichers } from 'evlog/enrichers'
+
+const enrichRequest = createDefaultEnrichers()
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('evlog:enrich', (context) => enrichRequest(context))
+})

--- a/apps/cms/server/services/generation/service.ts
+++ b/apps/cms/server/services/generation/service.ts
@@ -10,6 +10,7 @@ import { getCloudflareEnv } from '../../utils/cloudflare-env'
 import { useGenerationArtifactStore } from './artifact-storage'
 import { useGenerationProgressStore } from './progress'
 import { executeGenerationStep } from './step-runner'
+import { logBackgroundError, logRequestError } from '../../utils/logging'
 import { runInBackground, shouldDeferWorkToBackground } from '../../utils/background-task'
 import {
   GENERATION_REVIEW_EVENT_TYPE,
@@ -38,10 +39,18 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
         type: GENERATION_REVIEW_EVENT_TYPE,
         payload,
       })
-    }
-    catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      console.error(`[generation] sendEvent review failed for ${runId}: ${message}`)
+    } catch (error) {
+      const context = {
+        generation: {
+          operation: 'send-review-event',
+          runId,
+        },
+      }
+      if (event) {
+        logRequestError(event, error, context)
+      } else {
+        logBackgroundError('generation-review-event', error, context)
+      }
     }
   }
 
@@ -50,10 +59,12 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
       return queries.findById(runId)
     },
 
-    listAwaitingReview(input: {
-      excludeRequestedByUserId?: number | null
-      limit?: number
-    } = {}) {
+    listAwaitingReview(
+      input: {
+        excludeRequestedByUserId?: number | null
+        limit?: number
+      } = {}
+    ) {
       return queries.listAwaitingReview(input)
     },
 
@@ -95,7 +106,7 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
       }>(parent.artifactPrefix, 'discover')
 
       const all = discover?.candidates ?? []
-      const selected = all.filter(candidate => candidateIds.includes(candidate.id))
+      const selected = all.filter((candidate) => candidateIds.includes(candidate.id))
       if (selected.length === 0) {
         throw queryConflict('No matching candidates for the given ids')
       }
@@ -139,8 +150,8 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
       }
 
       await artifacts.putJson(parent.artifactPrefix, 'selection', {
-        selectedCandidateIds: selected.map(c => c.id),
-        childRunIds: children.map(c => c.id),
+        selectedCandidateIds: selected.map((c) => c.id),
+        childRunIds: children.map((c) => c.id),
         selectedByUserId,
         selectedAt: new Date().toISOString(),
       })
@@ -180,8 +191,7 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
             id: runId,
             params: { runId },
           })
-        }
-        catch (error) {
+        } catch (error) {
           // Revising may resume an existing instance via sendEvent only.
           const message = error instanceof Error ? error.message : String(error)
           if (!message.toLowerCase().includes('already')) {
@@ -203,12 +213,13 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
       }
 
       if (event && shouldDeferWorkToBackground(event)) {
-        await runInBackground(event, kick)
-      }
-      else {
+        await runInBackground(event, kick, {
+          task: 'generation-fallback',
+          runId,
+        })
+      } else {
         void kick().catch((error: unknown) => {
-          const message = error instanceof Error ? error.message : String(error)
-          console.error(`[generation] fallback kick failed for ${runId}: ${message}`)
+          logBackgroundError('generation-fallback', error, { runId })
         })
       }
 
@@ -223,13 +234,16 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
       })
     },
 
-    async reviewRun(runId: string, input: {
-      action: GenerationReviewAction
-      reviewerUserId: number
-      reviewNote?: string | null
-      reason?: string | null
-      focusSteps?: string[] | null
-    }) {
+    async reviewRun(
+      runId: string,
+      input: {
+        action: GenerationReviewAction
+        reviewerUserId: number
+        reviewNote?: string | null
+        reason?: string | null
+        focusSteps?: string[] | null
+      }
+    ) {
       const existing = await queries.findById(runId)
       if (!existing) {
         throw queryNotFound('Generation run not found')
@@ -271,17 +285,13 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
             reviewNote: note,
             focusSteps: input.focusSteps,
           })
-          await artifacts.putJson(
-            existing.artifactPrefix,
-            reviewNotesArtifactKey(result.round),
-            {
-              round: result.round,
-              reviewNote: note,
-              focusSteps: input.focusSteps ?? null,
-              reviewerUserId: input.reviewerUserId,
-              at: new Date().toISOString(),
-            },
-          )
+          await artifacts.putJson(existing.artifactPrefix, reviewNotesArtifactKey(result.round), {
+            round: result.round,
+            reviewNote: note,
+            focusSteps: input.focusSteps ?? null,
+            reviewerUserId: input.reviewerUserId,
+            at: new Date().toISOString(),
+          })
           await sendReviewEvent(runId, {
             action: 'request_changes',
             reviewerUserId: input.reviewerUserId,
@@ -314,8 +324,7 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
       for (const runId of claimed) {
         try {
           results.push(await this.processRunOnce(runId))
-        }
-        catch (error) {
+        } catch (error) {
           results.push({ runId, error: String(error) })
         }
       }
@@ -331,7 +340,9 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
           throw queryNotFound('Generation run not found')
         }
 
-        const nextStep = run.steps?.find(step => step.status === 'pending' || step.status === 'running')
+        const nextStep = run.steps?.find(
+          (step) => step.status === 'pending' || step.status === 'running'
+        )
         if (!nextStep) {
           const now = new Date().toISOString()
 
@@ -353,9 +364,14 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
             }
           }
 
-          const nextRound = run.status === 'revising'
-            ? (run.reviewRound && run.reviewRound > 0 ? run.reviewRound + 1 : 2)
-            : (run.reviewRound && run.reviewRound > 0 ? run.reviewRound : 1)
+          const nextRound =
+            run.status === 'revising'
+              ? run.reviewRound && run.reviewRound > 0
+                ? run.reviewRound + 1
+                : 2
+              : run.reviewRound && run.reviewRound > 0
+                ? run.reviewRound
+                : 1
 
           await queries.completeRunAwaitingReview(runId, {
             targetType: run.targetType,
@@ -392,20 +408,27 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
         await queries.markStepRunning(nextStep.id, attemptCount, nextStep.startedAt)
 
         try {
-          const linkedIds = nextStep.stepKey === 'assemble'
-            || nextStep.stepKey === 'revise_1'
-            || nextStep.stepKey === 'revise_2'
-            ? await queries.findRunLinkedIds(run.id)
-            : undefined
+          const linkedIds =
+            nextStep.stepKey === 'assemble' ||
+            nextStep.stepKey === 'revise_1' ||
+            nextStep.stepKey === 'revise_2'
+              ? await queries.findRunLinkedIds(run.id)
+              : undefined
 
-          let stepResult = await executeGenerationStep(artifacts, {
-            id: run.id,
-            targetType: run.targetType,
-            articleId: run.articleId,
-            recipeId: run.recipeId,
-            artifactPrefix: run.artifactPrefix,
-            requestedByUserId: run.requestedByUserId,
-          }, nextStep.stepKey, stepDeps, { linkedIds })
+          let stepResult = await executeGenerationStep(
+            artifacts,
+            {
+              id: run.id,
+              targetType: run.targetType,
+              articleId: run.articleId,
+              recipeId: run.recipeId,
+              artifactPrefix: run.artifactPrefix,
+              requestedByUserId: run.requestedByUserId,
+            },
+            nextStep.stepKey,
+            stepDeps,
+            { linkedIds }
+          )
 
           if (stepResult.pendingAssemble) {
             const linked = await queries.applyAssembledDraftAndLinkRun(run.id, {
@@ -444,10 +467,9 @@ export function createContentGenerationService(db: AppDb, event?: H3Event) {
           })
 
           processedSteps.push(nextStep.stepKey)
-        }
-        catch (error) {
-          const softFail = nextStep.stepKey === 'keyword_research'
-            || nextStep.stepKey === 'generate_cover'
+        } catch (error) {
+          const softFail =
+            nextStep.stepKey === 'keyword_research' || nextStep.stepKey === 'generate_cover'
 
           if (softFail) {
             const artifactKey = await artifacts.putJson(run.artifactPrefix, nextStep.stepKey, {

--- a/apps/cms/server/services/strapi-import-status.ts
+++ b/apps/cms/server/services/strapi-import-status.ts
@@ -30,11 +30,39 @@ function jobSlugsKey(lockId: string, step: StrapiImportBatchedStep) {
 export async function getStrapiImportStatus(event?: H3Event): Promise<StrapiImportProgress> {
   const store = useKvStore(event)
   const current = await store.get<StrapiImportProgress>(STATUS_KEY)
-  return current ?? {
-    status: 'idle',
+  const progress = current ?? {
+    status: 'idle' as const,
     dryRun: false,
     messages: [],
   }
+
+  // Overnight / crashed imports leave status=running after the lock TTL expires.
+  // Heal to idle so Maintenance + Import UI unlock without a manual reset.
+  if (progress.status === 'running') {
+    const lock = await store.get<StrapiImportLock>(LOCK_KEY)
+    if (!lock || isStaleLock(lock)) {
+      if (lock) {
+        await store.del(LOCK_KEY)
+        if (!useKv(event)) {
+          memoryLockOwner.id = null
+        }
+      }
+      const healed: StrapiImportProgress = {
+        status: 'idle',
+        dryRun: progress.dryRun,
+        messages: [
+          ...progress.messages,
+          'Import interrompu (verrou expiré) — état réinitialisé automatiquement.',
+        ].slice(-200),
+        finishedAt: new Date().toISOString(),
+        error: progress.error ?? 'Import bloqué: verrou expiré sans finalisation.',
+      }
+      await store.set(STATUS_KEY, healed, { ttl: STATUS_TTL })
+      return healed
+    }
+  }
+
+  return progress
 }
 
 export async function setStrapiImportStatus(

--- a/apps/cms/server/tasks/generation-process.ts
+++ b/apps/cms/server/tasks/generation-process.ts
@@ -1,3 +1,4 @@
+import { createLogger } from 'evlog'
 import { isSqliteBusyError } from '../utils/sqlite-busy'
 import { useContentGenerationService } from '../services/generation/service'
 
@@ -7,16 +8,25 @@ export default defineTask({
     description: 'Advance queued AI generation runs (bounded poller scaffold)',
   },
   async run() {
+    const log = createLogger({ task: 'generation-process' })
     try {
       const result = await useContentGenerationService().processDueRuns(5)
+      log.set({ outcome: 'success', generation: result })
       return { result }
-    }
-    catch (error) {
+    } catch (error) {
       if (isSqliteBusyError(error)) {
-        console.warn('[generation-process] skipped — database busy')
-        return { result: { claimed: 0, skipped: true as const } }
+        log.warn('Generation processing skipped because the database is busy.', {
+          outcome: 'skipped',
+          reason: 'sqlite_busy',
+        })
+        return { result: { claimed: 0, results: [] } }
       }
+      log.error(error instanceof Error ? error : String(error), {
+        outcome: 'failure',
+      })
       throw error
+    } finally {
+      log.emit()
     }
   },
 })

--- a/apps/cms/server/tasks/publish-scheduled.ts
+++ b/apps/cms/server/tasks/publish-scheduled.ts
@@ -1,3 +1,4 @@
+import { createLogger } from 'evlog'
 import { usePublishingService } from '../services/publishing-service'
 import { isSqliteBusyError } from '../utils/sqlite-busy'
 
@@ -7,16 +8,25 @@ export default defineTask({
     description: 'Publish content whose scheduledAt has passed',
   },
   async run() {
+    const log = createLogger({ task: 'publish-scheduled' })
     try {
       const result = await usePublishingService().publishDueScheduled()
+      log.set({ outcome: 'success', publishing: result })
       return { result }
-    }
-    catch (error) {
+    } catch (error) {
       if (isSqliteBusyError(error)) {
-        console.warn('[publish-scheduled] skipped — database busy')
-        return { result: { published: 0, skipped: true as const } }
+        log.warn('Scheduled publishing skipped because the database is busy.', {
+          outcome: 'skipped',
+          reason: 'sqlite_busy',
+        })
+        return { result: { published: 0, skipped: 0 } }
       }
+      log.error(error instanceof Error ? error : String(error), {
+        outcome: 'failure',
+      })
       throw error
+    } finally {
+      log.emit()
     }
   },
 })

--- a/apps/cms/server/tasks/seed-admin.ts
+++ b/apps/cms/server/tasks/seed-admin.ts
@@ -1,3 +1,4 @@
+import { createLogger } from 'evlog'
 import { seedAdmin } from '../db/seed/admin'
 import { resolveSeedAdminInput, seedAdminPayloadSchema } from '../db/seed/defaults'
 import { useDb } from '../utils/db'
@@ -8,14 +9,31 @@ export default defineTask({
     description: 'Create the initial CMS admin user (idempotent)',
   },
   async run({ payload }) {
-    const parsed = seedAdminPayloadSchema.safeParse(payload ?? {})
-    if (!parsed.success) {
-      throw new Error(`Invalid seed-admin payload: ${parsed.error.message}`)
+    const log = createLogger({ task: 'seed-admin' })
+    try {
+      const parsed = seedAdminPayloadSchema.safeParse(payload ?? {})
+      if (!parsed.success) {
+        throw new Error(`Invalid seed-admin payload: ${parsed.error.message}`)
+      }
+
+      const db = useDb()
+      const result = await seedAdmin(db, resolveSeedAdminInput(parsed.data))
+
+      log.set({
+        outcome: result.skipped ? 'skipped' : 'success',
+        admin: {
+          userId: result.user?.id,
+          skipped: result.skipped,
+        },
+      })
+      return { result }
+    } catch (error) {
+      log.error(error instanceof Error ? error : String(error), {
+        outcome: 'failure',
+      })
+      throw error
+    } finally {
+      log.emit()
     }
-
-    const db = useDb()
-    const result = await seedAdmin(db, resolveSeedAdminInput(parsed.data))
-
-    return { result }
   },
 })

--- a/apps/cms/server/tasks/strapi-extract.ts
+++ b/apps/cms/server/tasks/strapi-extract.ts
@@ -1,10 +1,11 @@
+import { createLogger } from 'evlog'
 import { z } from 'zod'
 import { STRAPI_IMPORT_STEPS } from '../../shared/strapi-import'
+import { acquireStrapiImportLock, getStrapiImportStatus } from '../services/strapi-import-status'
 import {
-  acquireStrapiImportLock,
-  getStrapiImportStatus,
-} from '../services/strapi-import-status'
-import { executeStrapiImportToCompletion, primeStrapiImportStatus } from '../services/strapi-import-runner'
+  executeStrapiImportToCompletion,
+  primeStrapiImportStatus,
+} from '../services/strapi-import-runner'
 
 const payloadSchema = z.object({
   dryRun: z.boolean().optional(),
@@ -17,40 +18,62 @@ export default defineTask({
     description: 'Import content and media from Strapi into the CMS database',
   },
   async run({ payload }) {
-    const parsed = payloadSchema.safeParse(payload ?? {})
-    if (!parsed.success) {
-      throw new Error(`Invalid strapi-extract payload: ${parsed.error.message}`)
-    }
+    const log = createLogger({ task: 'strapi-extract' })
+    try {
+      const parsed = payloadSchema.safeParse(payload ?? {})
+      if (!parsed.success) {
+        throw new Error(`Invalid strapi-extract payload: ${parsed.error.message}`)
+      }
 
-    const config = useRuntimeConfig()
-    if (!config.strapiUrl) {
-      throw new Error('STRAPI_URL is not configured')
-    }
+      const config = useRuntimeConfig()
+      if (!config.strapiUrl) {
+        throw new Error('STRAPI_URL is not configured')
+      }
 
-    const current = await getStrapiImportStatus()
-    if (current.status === 'running') {
-      throw new Error('Strapi import already running')
-    }
+      const current = await getStrapiImportStatus()
+      if (current.status === 'running') {
+        throw new Error('Strapi import already running')
+      }
 
-    const lockId = await acquireStrapiImportLock()
-    if (!lockId) {
-      throw new Error('Could not acquire import lock')
-    }
+      const lockId = await acquireStrapiImportLock()
+      if (!lockId) {
+        throw new Error('Could not acquire import lock')
+      }
 
-    const dryRun = parsed.data.dryRun ?? false
-    await primeStrapiImportStatus(undefined, dryRun)
+      const dryRun = parsed.data.dryRun ?? false
+      log.set({
+        strapiImport: {
+          dryRun,
+          steps: parsed.data.steps,
+        },
+      })
+      await primeStrapiImportStatus(undefined, dryRun)
 
-    const outcome = await executeStrapiImportToCompletion(undefined, {
-      dryRun,
-      steps: parsed.data.steps,
-    }, lockId)
+      const outcome = await executeStrapiImportToCompletion(
+        undefined,
+        {
+          dryRun,
+          steps: parsed.data.steps,
+        },
+        lockId
+      )
 
-    if (!outcome) {
+      if (!outcome) {
+        const status = await getStrapiImportStatus()
+        throw new Error(status.error ?? 'Strapi import failed')
+      }
+
       const status = await getStrapiImportStatus()
-      throw new Error(status.error ?? 'Strapi import failed')
+      const result = status.result ?? outcome.result
+      log.set({ outcome: 'success', strapiImport: { result } })
+      return { result }
+    } catch (error) {
+      log.error(error instanceof Error ? error : String(error), {
+        outcome: 'failure',
+      })
+      throw error
+    } finally {
+      log.emit()
     }
-
-    const status = await getStrapiImportStatus()
-    return { result: status.result ?? outcome.result }
   },
 })

--- a/apps/cms/server/tasks/strapi-media-hydrate.ts
+++ b/apps/cms/server/tasks/strapi-media-hydrate.ts
@@ -1,3 +1,4 @@
+import { createLogger } from 'evlog'
 import { z } from 'zod'
 import { getLocalDb } from '../db/client'
 import { hydrateStrapiMedia } from '../services/hydrate-strapi-media'
@@ -20,30 +21,41 @@ export default defineTask({
     description: 'Download remaining Strapi /uploads media and rewrite content URLs',
   },
   async run({ payload }) {
-    const parsed = payloadSchema.safeParse(payload ?? {})
-    if (!parsed.success) {
-      throw new Error(`Invalid strapi-media-hydrate payload: ${parsed.error.message}`)
+    const log = createLogger({ task: 'strapi-media-hydrate' })
+    try {
+      const parsed = payloadSchema.safeParse(payload ?? {})
+      if (!parsed.success) {
+        throw new Error(`Invalid strapi-media-hydrate payload: ${parsed.error.message}`)
+      }
+
+      const config = useRuntimeConfig()
+      if (!config.strapiUrl) {
+        throw new Error('STRAPI_URL is not configured')
+      }
+
+      // Force libSQL for this heavy download job when not explicitly on D1.
+      const db = prefersD1Database() ? useDb() : getLocalDb()
+
+      const result = await hydrateStrapiMedia({
+        db,
+        strapiUrl: config.strapiUrl,
+        strapiApiToken: config.strapiApiToken || undefined,
+        strapiUploadsOrigin: config.strapiUploadsOrigin || undefined,
+        dryRun: parsed.data.dryRun ?? false,
+        slug: parsed.data.slug,
+        delayMs: parsed.data.delayMs,
+        log: (message) => log.info(message),
+      })
+
+      log.set({ outcome: 'success', hydration: result })
+      return { result }
+    } catch (error) {
+      log.error(error instanceof Error ? error : String(error), {
+        outcome: 'failure',
+      })
+      throw error
+    } finally {
+      log.emit()
     }
-
-    const config = useRuntimeConfig()
-    if (!config.strapiUrl) {
-      throw new Error('STRAPI_URL is not configured')
-    }
-
-    // Force libSQL for this heavy download job when not explicitly on D1.
-    const db = prefersD1Database() ? useDb() : getLocalDb()
-
-    const result = await hydrateStrapiMedia({
-      db,
-      strapiUrl: config.strapiUrl,
-      strapiApiToken: config.strapiApiToken || undefined,
-      strapiUploadsOrigin: config.strapiUploadsOrigin || undefined,
-      dryRun: parsed.data.dryRun ?? false,
-      slug: parsed.data.slug,
-      delayMs: parsed.data.delayMs,
-      log: (message) => console.log(`[strapi-media-hydrate] ${message}`),
-    })
-
-    return { result }
   },
 })

--- a/apps/cms/server/utils/background-task.ts
+++ b/apps/cms/server/utils/background-task.ts
@@ -1,14 +1,19 @@
 import type { H3Event } from 'h3'
+import { logBackgroundError, type LogContext } from './logging'
 
 type CloudflareExecutionContext = {
   waitUntil?: (promise: Promise<unknown>) => void
 }
 
 function getCloudflareContext(event: H3Event) {
-  return (event.context.cloudflare as {
-    context?: CloudflareExecutionContext
-    waitUntil?: (promise: Promise<unknown>) => void
-  } | undefined)?.context
+  return (
+    event.context.cloudflare as
+      | {
+          context?: CloudflareExecutionContext
+          waitUntil?: (promise: Promise<unknown>) => void
+        }
+      | undefined
+  )?.context
 }
 
 /**
@@ -27,10 +32,14 @@ export function shouldDeferWorkToBackground(event: H3Event): boolean {
  * Runs work after the HTTP response on Workers (`waitUntil`).
  * In local dev, awaits the work so imports actually finish.
  */
-export async function runInBackground(event: H3Event, work: () => Promise<void>) {
+export async function runInBackground(
+  event: H3Event,
+  work: () => Promise<void>,
+  context: LogContext & { task?: string } = {}
+) {
   const promise = work().catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error)
-    console.error(`[background-task] ${message}`)
+    const { task = 'background-task', ...details } = context
+    logBackgroundError(task, error, details)
   })
 
   const ctx = getCloudflareContext(event)

--- a/apps/cms/server/utils/errors.ts
+++ b/apps/cms/server/utils/errors.ts
@@ -28,11 +28,21 @@ export function createApiError(
   code: ApiErrorCode,
   message: string,
   details?: unknown,
-  options?: { why?: string, fix?: string },
+  options?: {
+    status?: number
+    why?: string
+    fix?: string
+    cause?: Error
+    internal?: Record<string, unknown>
+  }
 ) {
   const why = options?.why ?? message
   const fix = options?.fix ?? FIX_HINTS[code]
-  const statusCode = STATUS_BY_CODE[code]
+  const statusCode = options?.status ?? STATUS_BY_CODE[code]
+  const internal = {
+    ...(details === undefined ? {} : { details }),
+    ...options?.internal,
+  }
 
   const clientBody = {
     error: {
@@ -50,7 +60,8 @@ export function createApiError(
     status: statusCode,
     why,
     fix,
-    internal: details === undefined ? undefined : { details },
+    cause: options?.cause,
+    internal: Object.keys(internal).length > 0 ? internal : undefined,
   })
 
   return h3CreateError({

--- a/apps/cms/server/utils/kv.ts
+++ b/apps/cms/server/utils/kv.ts
@@ -2,6 +2,7 @@ import type { H3Event } from 'h3'
 import type { createSiteSettingsQueries } from '../db/queries/site-settings'
 import { getCloudflareEnv } from './cloudflare-env'
 import { prefersD1Database, useQueries } from './db'
+import { logBackgroundWarning, logRequestWarning } from './logging'
 
 export function useKv(event?: H3Event): KVNamespace | undefined {
   return getCloudflareEnv(event)?.Cache
@@ -30,7 +31,7 @@ export function createKvStore(kv: KVNamespace): KvStore {
 }
 
 function createSiteSettingsStore(
-  siteSettings: ReturnType<typeof createSiteSettingsQueries>,
+  siteSettings: ReturnType<typeof createSiteSettingsQueries>
 ): KvStore {
   return {
     async get<T>(key: string) {
@@ -46,7 +47,7 @@ function createSiteSettingsStore(
   }
 }
 
-const memory = new Map<string, { value: unknown, expiresAt?: number }>()
+const memory = new Map<string, { value: unknown; expiresAt?: number }>()
 
 /** In-memory KV fallback for local `nuxt dev` without Cloudflare bindings. */
 export const memoryKvStore: KvStore = {
@@ -89,9 +90,19 @@ export function useKvStore(event?: H3Event): KvStore {
   const env = getCloudflareEnv(event)
   if (env?.DB && !warnedMemoryKvWithoutBinding) {
     warnedMemoryKvWithoutBinding = true
-    console.warn(
-      '[cms] Cache KV binding missing while D1 is present — using in-memory store (import journal will not persist across requests).',
-    )
+    const message = 'Cache KV binding missing while D1 is present; using in-memory storage.'
+    const context = {
+      cache: {
+        provider: 'memory',
+        persistence: 'request-local',
+        reason: 'missing-binding',
+      },
+    }
+    if (event) {
+      logRequestWarning(event, message, context)
+    } else {
+      logBackgroundWarning('cache-fallback', message, context)
+    }
   }
 
   return memoryKvStore

--- a/apps/cms/server/utils/logging.ts
+++ b/apps/cms/server/utils/logging.ts
@@ -1,0 +1,41 @@
+import type { H3Event } from 'h3'
+import { createLogger, useLogger } from 'evlog'
+
+export type LogContext = Record<string, unknown>
+
+/** Preserve useful error details when a boundary receives an unknown value. */
+export function toLogError(error: unknown): Error | string {
+  if (error instanceof Error || typeof error === 'string') {
+    return error
+  }
+
+  try {
+    return JSON.stringify(error) ?? String(error)
+  } catch {
+    return String(error)
+  }
+}
+
+/** Add an error to the current request's single evlog wide event. */
+export function logRequestError(event: H3Event, error: unknown, context?: LogContext) {
+  useLogger(event as Parameters<typeof useLogger>[0]).error(toLogError(error), context)
+}
+
+/** Add a warning to the current request's single evlog wide event. */
+export function logRequestWarning(event: H3Event, message: string, context?: LogContext) {
+  useLogger(event as Parameters<typeof useLogger>[0]).warn(message, context)
+}
+
+/** Emit one standalone wide event for work that runs outside an HTTP request. */
+export function logBackgroundError(task: string, error: unknown, context?: LogContext) {
+  const log = createLogger({ task })
+  log.error(toLogError(error), context)
+  log.emit()
+}
+
+/** Emit one standalone wide event for a warning from a task or worker callback. */
+export function logBackgroundWarning(task: string, message: string, context?: LogContext) {
+  const log = createLogger({ task })
+  log.warn(message, context)
+  log.emit()
+}

--- a/apps/cms/server/utils/workers-image-cache.ts
+++ b/apps/cms/server/utils/workers-image-cache.ts
@@ -3,13 +3,17 @@ import { imageDeliveryCacheTags } from '../../shared/image-delivery-policy'
 import { runInBackground } from './background-task'
 
 export interface WorkersCachePurge {
-  purge(options: { tags?: string[], prefixes?: string[] }): Promise<unknown>
+  purge(options: { tags?: string[]; prefixes?: string[] }): Promise<unknown>
 }
 
 function getWorkersCache(event: H3Event): WorkersCachePurge | undefined {
-  const ctx = (event.context.cloudflare as {
-    context?: { cache?: WorkersCachePurge }
-  } | undefined)?.context
+  const ctx = (
+    event.context.cloudflare as
+      | {
+          context?: { cache?: WorkersCachePurge }
+        }
+      | undefined
+  )?.context
   const cache = ctx?.cache
   if (cache && typeof cache.purge === 'function') {
     return cache
@@ -31,9 +35,13 @@ export async function purgeImageDeliveryCache(event: H3Event, assetPath: string)
     return
   }
   const tags = imageDeliveryCacheTagList(assetPath)
-  await runInBackground(event, async () => {
-    await cache.purge({ tags })
-  })
+  await runInBackground(
+    event,
+    async () => {
+      await cache.purge({ tags })
+    },
+    { task: 'purge-image-delivery-cache', assetPath, tags }
+  )
 }
 
 /** Purge all image variants (e.g. maintenance wipe). */
@@ -42,7 +50,11 @@ export async function purgeAllMediaImageCache(event: H3Event) {
   if (!cache) {
     return
   }
-  await runInBackground(event, async () => {
-    await cache.purge({ tags: ['media'] })
-  })
+  await runInBackground(
+    event,
+    async () => {
+      await cache.purge({ tags: ['media'] })
+    },
+    { task: 'purge-all-media-image-cache' }
+  )
 }

--- a/apps/cms/shared/error-code.ts
+++ b/apps/cms/shared/error-code.ts
@@ -1,0 +1,30 @@
+const NUXT_DIAGNOSTIC_CODE = /^NUXT_[A-Z]\d{4}$/
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value) => typeof value === 'string' && value.length > 0) as string | undefined
+}
+
+/**
+ * Extract Nuxt diagnostic codes and application/API error codes from either
+ * an Error instance or a serialized Nuxt/ofetch error response.
+ */
+export function getErrorCode(error: unknown): string | undefined {
+  const record = asRecord(error)
+  if (!record) return undefined
+
+  const data = asRecord(record.data)
+  const nestedData = asRecord(data?.data)
+  const nestedError = asRecord(data?.error)
+  const payloadCode = firstString(data?.code, nestedData?.code, nestedError?.code)
+  if (payloadCode) return payloadCode
+
+  const directCode = firstString(record.code)
+  if (directCode) return directCode
+
+  const name = record.name
+  return typeof name === 'string' && NUXT_DIAGNOSTIC_CODE.test(name) ? name : undefined
+}

--- a/apps/cms/shared/strapi-url.ts
+++ b/apps/cms/shared/strapi-url.ts
@@ -7,14 +7,14 @@ export function normalizeStrapiApiBase(url: string): string {
 
 /** Origins to try for `/uploads/…` static files (admin vs public site). */
 export function strapiUploadOrigins(apiBase: string, extraOrigin?: string): string[] {
-  const origins = [
+  const fromEnv = [
     extraOrigin,
+    process.env.STRAPI_UPLOADS_ORIGIN,
+    process.env.NUXT_PUBLIC_SITE_URL,
     normalizeStrapiApiBase(apiBase),
-    'https://admin.journalducuistot.fr',
-    'https://journalducuistot.fr',
   ].filter((value): value is string => Boolean(value?.trim()))
 
-  return [...new Set(origins.map(origin => origin.replace(/\/$/, '')))]
+  return [...new Set(fromEnv.map(origin => origin.replace(/\/$/, '')))]
 }
 
 async function downloadOnce(
@@ -63,7 +63,12 @@ export async function fetchStrapiUploadBinary(
   opts?: { origins: string[], token?: string, timeoutMs?: number, retries?: number },
 ): Promise<ArrayBuffer> {
   const path = relativeUrl.startsWith('/') ? relativeUrl : `/${relativeUrl}`
-  const origins = opts?.origins?.length ? opts.origins : ['https://admin.journalducuistot.fr']
+  const origins = opts?.origins?.length
+    ? opts.origins
+    : strapiUploadOrigins(process.env.STRAPI_URL || '')
+  if (!origins.length) {
+    throw new Error('No Strapi upload origins configured (set STRAPI_URL or pass opts.origins)')
+  }
   const timeoutMs = opts?.timeoutMs ?? 120_000
   const retries = opts?.retries ?? 2
 

--- a/apps/cms/test/unit/error-code.test.ts
+++ b/apps/cms/test/unit/error-code.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { getErrorCode } from '../../shared/error-code'
+
+describe('getErrorCode', () => {
+  it('reads a Nuxt diagnostic code from an error instance', () => {
+    const error = Object.assign(new Error('Missing Nuxt context'), {
+      code: 'NUXT_E1001',
+    })
+
+    expect(getErrorCode(error)).toBe('NUXT_E1001')
+  })
+
+  it('reads a serialized Nuxt diagnostic code from the error name', () => {
+    expect(
+      getErrorCode({
+        name: 'NUXT_E1001',
+        message: 'Missing Nuxt context',
+      })
+    ).toBe('NUXT_E1001')
+  })
+
+  it('reads application codes from an API error envelope', () => {
+    expect(
+      getErrorCode({
+        data: {
+          error: {
+            code: 'INTERNAL_ERROR',
+          },
+        },
+      })
+    ).toBe('INTERNAL_ERROR')
+  })
+
+  it('prefers the application code over a transport error code', () => {
+    expect(
+      getErrorCode({
+        code: 'ERR_BAD_REQUEST',
+        data: {
+          error: {
+            code: 'FORBIDDEN',
+          },
+        },
+      })
+    ).toBe('FORBIDDEN')
+  })
+
+  it('ignores a generic Error name when no code is available', () => {
+    expect(getErrorCode(new Error('Unknown failure'))).toBeUndefined()
+  })
+})

--- a/apps/web/app/composables/useLoadMeta.ts
+++ b/apps/web/app/composables/useLoadMeta.ts
@@ -32,7 +32,10 @@ export const useLoadMeta = (metaOption: MetaOption): MetaData => {
     type: isArticle ? "article" : "website",
     title: metaOption.title,
     description,
-    robots: "index, follow, max-image-preview:large",
+    robots:
+      site.indexable === false
+        ? "noindex, nofollow"
+        : "index, follow, max-image-preview:large",
     keywords,
     ogType: isArticle ? "article" : "website",
     ogLocale: "fr-FR",

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -105,9 +105,12 @@ export default defineNuxtConfig({
   },
 
   nitro: {
+    // Same preset Alchemy Website.Nuxt enforces — keep for standalone `pnpm build`.
+    // A *different* preset would hard-error under Alchemy.
     preset: 'cloudflare_module',
     compatibilityDate: '2026-05-27',
     cloudflare: {
+      // Alchemy Website.Nuxt forces deployConfig:false (wrangler-free).
       deployConfig: true,
       wrangler: {
         compatibility_flags: ['nodejs_compat_v2'],

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -134,6 +134,7 @@ export default defineNuxtConfig({
     description: siteDescription,
     defaultLocale: 'fr',
     identity: siteIdentity,
+    indexable: process.env.NUXT_SITE_INDEXABLE !== 'false',
   },
 
   seo: {
@@ -222,11 +223,13 @@ export default defineNuxtConfig({
   },
 
   umami: {
-    id: process.env.NUXT_PUBLIC_UMAMI_ID || process.env.NUXT_UMAMI_ID,
+    id: process.env.NUXT_UMAMI_ID,
     host: process.env.NUXT_UMAMI_HOST,
     autoTrack: true,
     ignoreLocalhost: true,
     enabled: true,
+    // Core Web Vitals (LCP, FCP, CLS, INP, TTFB) — requires Umami v3.1.0+
+    performance: true,
   },
 
   runtimeConfig: {

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -15,7 +15,7 @@ const skewProtectionBundleAssets = Boolean(
   skewProtectionKvNamespaceId !== 'skew-protection-local'
 )
 
-const siteUrl = process.env.NUXT_PUBLIC_SITE_URL || 'https://journalducuistot.fr'
+const siteUrl = process.env.NUXT_PUBLIC_SITE_URL || 'http://localhost:3000'
 const siteOrigin = siteUrl.replace(/\/$/, '')
 const siteName = process.env.NUXT_SITE_NAME || 'Journal du cuistot'
 const siteDescription =
@@ -39,7 +39,7 @@ export default defineNuxtConfig({
       link: [{ rel: 'icon', type: 'image/webp', href: '/img/logo.webp' }],
       /* script: [
         {
-          src: "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5406721051491594",
+          src: "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js",
           async: true,
           crossorigin: "anonymous",
           type: "text/partytown",

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -1,42 +1,42 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-import { fileURLToPath } from "node:url";
-import listRedirects from "./app/utils/redirect";
-import tailwindcss from "@tailwindcss/vite";
-import { resolveSiteIdentity } from "./shared/site-identity";
+import { fileURLToPath } from 'node:url'
+import listRedirects from './app/utils/redirect'
+import tailwindcss from '@tailwindcss/vite'
+import { resolveSiteIdentity } from './shared/site-identity'
 
-const webRoot = fileURLToPath(new URL(".", import.meta.url));
+const webRoot = fileURLToPath(new URL('.', import.meta.url))
 
 const skewProtectionKvNamespaceId =
-  process.env.SKEW_PROTECTION_KV_NAMESPACE_ID || "skew-protection-local";
+  process.env.SKEW_PROTECTION_KV_NAMESPACE_ID || 'skew-protection-local'
 /** KV asset bundling only on deploy builds (real namespace + token), not local defaults. */
 const skewProtectionBundleAssets = Boolean(
-  process.env.CLOUDFLARE_API_TOKEN
-  && process.env.SKEW_PROTECTION_KV_NAMESPACE_ID
-  && skewProtectionKvNamespaceId !== "skew-protection-local",
-);
+  process.env.CLOUDFLARE_API_TOKEN &&
+  process.env.SKEW_PROTECTION_KV_NAMESPACE_ID &&
+  skewProtectionKvNamespaceId !== 'skew-protection-local'
+)
 
-const siteUrl = process.env.NUXT_PUBLIC_SITE_URL || "https://journalducuistot.fr";
-const siteOrigin = siteUrl.replace(/\/$/, "");
-const siteName = process.env.NUXT_SITE_NAME || "Journal du cuistot";
+const siteUrl = process.env.NUXT_PUBLIC_SITE_URL || 'https://journalducuistot.fr'
+const siteOrigin = siteUrl.replace(/\/$/, '')
+const siteName = process.env.NUXT_SITE_NAME || 'Journal du cuistot'
 const siteDescription =
   process.env.NUXT_SITE_DESCRIPTION ||
-  "Bienvenue sur le journal du cuistot, un blog de recettes de cuisine d'un globe-trotter";
-const siteIdentity = resolveSiteIdentity({ siteOrigin, siteName });
+  "Bienvenue sur le journal du cuistot, un blog de recettes de cuisine d'un globe-trotter"
+const siteIdentity = resolveSiteIdentity({ siteOrigin, siteName })
 
 export default defineNuxtConfig({
   compatibilityDate: '2026-07-20',
 
   future: {
-    compatibilityVersion: 5
+    compatibilityVersion: 5,
   },
 
   app: {
     head: {
       titleTemplate: '%s — %siteName',
       htmlAttrs: {
-        lang: 'fr' // Set the default language here
+        lang: 'fr', // Set the default language here
       },
-      link: [{ rel: "icon", type: "image/webp", href: "/img/logo.webp" }],
+      link: [{ rel: 'icon', type: 'image/webp', href: '/img/logo.webp' }],
       /* script: [
         {
           src: "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5406721051491594",
@@ -49,14 +49,14 @@ export default defineNuxtConfig({
   },
 
   modules: [
-    "@nuxtjs/seo",
-    "nuxt-ai-ready",
-    "nuxt-skew-protection",
-    "@nuxt/fonts",
-    "@nuxt/icon",
-    "@nuxtjs/partytown",
-    "@nuxt/image",
-    "@vueuse/nuxt",
+    '@nuxtjs/seo',
+    'nuxt-ai-ready',
+    'nuxt-skew-protection',
+    '@nuxt/fonts',
+    '@nuxt/icon',
+    '@nuxtjs/partytown',
+    '@nuxt/image',
+    '@vueuse/nuxt',
     /*    [
        "@nuxtjs/google-fonts",
        {
@@ -69,7 +69,7 @@ export default defineNuxtConfig({
          },
        }
        ], */
-    "nuxt-umami",
+    'nuxt-umami',
   ],
 
   css: ['~/assets/css/index.css'],
@@ -79,58 +79,33 @@ export default defineNuxtConfig({
   },
 
   routeRules: {
-    "/": { isr: 60 * 15 },
-    "/blog/**": { isr: 60 * 25 },
-    "/images/**": {
+    '/': { isr: 60 * 15 },
+    '/blog/**': { isr: 60 * 25 },
+    '/images/**': {
       isr: 60 * 60 * 24 * 30,
       headers: {
         'Cache-Control': 'public, max-age=31536000, stale-while-revalidate=604800',
       },
     },
-    "/sitemap.xml": { isr: 60 * 60 * 24 },
-    "/rss.xml": { isr: 60 * 60 * 24 * 3 },
-    "/preview": { robots: false },
-    "/preview/**": { robots: false },
+    '/sitemap.xml': { isr: 60 * 60 * 24 },
+    '/rss.xml': { isr: 60 * 60 * 24 * 3 },
+    '/preview': { robots: false },
+    '/preview/**': { robots: false },
     ...listRedirects,
 
-    "/*/**": {
+    '/*/**': {
       ogImage: {
-        component: "Cooking",
+        component: 'Cooking',
         props: {
-          title: "Journal du cuistot",
+          title: 'Journal du cuistot',
         },
       },
-
     },
   },
 
   nitro: {
-    // Same preset Alchemy Website.Nuxt enforces — keep for standalone `pnpm build`.
-    // A *different* preset would hard-error under Alchemy.
-    preset: 'cloudflare_module',
-    compatibilityDate: '2026-05-27',
-    cloudflare: {
-      // Alchemy Website.Nuxt forces deployConfig:false (wrangler-free).
-      deployConfig: true,
-      wrangler: {
-        compatibility_flags: ['nodejs_compat_v2'],
-        d1_databases: [
-          {
-            binding: 'AI_READY_DB',
-            database_name: 'ai-ready-local',
-            database_id: 'ai-ready-local',
-          },
-        ],
-        kv_namespaces: [
-          {
-            binding: 'SKEW_PROTECTION',
-            id: skewProtectionKvNamespaceId,
-          },
-        ],
-      },
-    },
     experimental: {
-      tasks: true
+      tasks: true,
     },
     ...(process.env.REDIS_URL
       ? {
@@ -141,35 +116,38 @@ export default defineNuxtConfig({
       : {}),
   },
 
-  components: [{
-    path: '~/components',
-    ignore: ['prose/**'],
-  }, {
-    global: true,
-    path: '~/components/prose',
-    /*  pathPrefix: false, */
-  }],
+  components: [
+    {
+      path: '~/components',
+      ignore: ['prose/**'],
+    },
+    {
+      global: true,
+      path: '~/components/prose',
+      /*  pathPrefix: false, */
+    },
+  ],
 
   site: {
     url: siteUrl,
     name: siteName,
     description: siteDescription,
-    defaultLocale: "fr",
+    defaultLocale: 'fr',
     identity: siteIdentity,
   },
 
   seo: {
     meta: {
-      ogLocale: "fr_FR",
-      ogType: "website",
-      twitterCard: "summary_large_image",
+      ogLocale: 'fr_FR',
+      ogType: 'website',
+      twitterCard: 'summary_large_image',
     },
   },
 
   aiReady: {
     database: {
-      type: "d1",
-      bindingName: "AI_READY_DB",
+      type: 'd1',
+      bindingName: 'AI_READY_DB',
     },
     contentSignal: {
       aiTrain: true,
@@ -179,52 +157,51 @@ export default defineNuxtConfig({
     llmsTxt: {
       sections: [
         {
-          title: "Contenu",
+          title: 'Contenu',
           links: [
             {
-              title: "Blog",
-              href: "/blog",
-              description: "Articles et actualités cuisine",
+              title: 'Blog',
+              href: '/blog',
+              description: 'Articles et actualités cuisine',
             },
             {
-              title: "Recettes",
-              href: "/recette",
-              description: "Catalogue des recettes",
+              title: 'Recettes',
+              href: '/recette',
+              description: 'Catalogue des recettes',
             },
           ],
         },
         {
-          title: "Flux et index",
+          title: 'Flux et index',
           links: [
             {
-              title: "RSS",
-              href: "/rss.xml",
-              description: "Flux RSS du site",
+              title: 'RSS',
+              href: '/rss.xml',
+              description: 'Flux RSS du site',
             },
             {
-              title: "Index IA",
-              href: "/api/sitemap-ia",
-              description: "Routes groupées pour agents",
+              title: 'Index IA',
+              href: '/api/sitemap-ia',
+              description: 'Routes groupées pour agents',
             },
             {
-              title: "Plan du site",
-              href: "/sitemap.xml",
-              description: "Index XML des sitemaps",
+              title: 'Plan du site',
+              href: '/sitemap.xml',
+              description: 'Index XML des sitemaps',
             },
           ],
         },
       ],
-      notes:
-        "Journal du cuistot — recettes et articles de cuisine en français (fr-FR).",
+      notes: 'Journal du cuistot — recettes et articles de cuisine en français (fr-FR).',
     },
   },
 
   skewProtection: {
-    updateStrategy: "polling",
+    updateStrategy: 'polling',
     bundleAssets: skewProtectionBundleAssets,
     storage: {
-      driver: "cloudflare-kv-binding",
-      binding: "SKEW_PROTECTION",
+      driver: 'cloudflare-kv-binding',
+      binding: 'SKEW_PROTECTION',
       namespaceId: skewProtectionKvNamespaceId,
     },
   },
@@ -236,7 +213,7 @@ export default defineNuxtConfig({
   image: {
     providers: {
       localImageSharp: {
-        provider: "~/providers/localImageSharp",
+        provider: '~/providers/localImageSharp',
         options: {
           baseURL: `/images/`,
         },
@@ -250,7 +227,6 @@ export default defineNuxtConfig({
     autoTrack: true,
     ignoreLocalhost: true,
     enabled: true,
-
   },
 
   runtimeConfig: {
@@ -261,53 +237,47 @@ export default defineNuxtConfig({
       identity: siteIdentity,
     },
     public: {
-      language: "fr-FR", // prefer more explicit language codes like `en-AU` over `en`
+      language: 'fr-FR', // prefer more explicit language codes like `en-AU` over `en`
       cmsBaseUrl: process.env.NUXT_PUBLIC_CMS_BASE_URL || 'http://localhost:3001',
       apiBase: process.env.NUXT_PUBLIC_CMS_BASE_URL || 'http://localhost:3001',
     },
   },
 
   sitemap: {
-    exclude: [
-      "/preview",
-      "/preview/**",
-      "/api/**",
-      "/images/**",
-    ],
+    exclude: ['/preview', '/preview/**', '/api/**', '/images/**'],
     sitemaps: {
       pages: {
         includeAppSources: true,
-        sitemapName: "sitemap-pages.xml",
-        sources: ["/api/__sitemap__/urls"],
-        exclude: ["/blog", "/blog/**", "/recette", "/recette/**"],
+        sitemapName: 'sitemap-pages.xml',
+        sources: ['/api/__sitemap__/urls'],
+        exclude: ['/blog', '/blog/**', '/recette', '/recette/**'],
         defaults: {
-          changefreq: "daily" as const,
+          changefreq: 'daily' as const,
           priority: 0.8,
         },
       },
       blog: {
         includeAppSources: true,
-        include: ["/blog", "/blog/**"],
-        sitemapName: "sitemap-blog.xml",
-        sources: ["/api/__sitemap__/urls"],
+        include: ['/blog', '/blog/**'],
+        sitemapName: 'sitemap-blog.xml',
+        sources: ['/api/__sitemap__/urls'],
         defaults: {
-          changefreq: "daily" as const,
+          changefreq: 'daily' as const,
           priority: 0.8,
         },
       },
       recipes: {
         includeAppSources: true,
-        include: ["/recette", "/recette/**"],
-        sitemapName: "sitemap-recipes.xml",
-        sources: ["/api/__sitemap__/urls"],
+        include: ['/recette', '/recette/**'],
+        sitemapName: 'sitemap-recipes.xml',
+        sources: ['/api/__sitemap__/urls'],
         defaults: {
-          changefreq: "daily" as const,
+          changefreq: 'daily' as const,
           priority: 0.8,
         },
       },
     },
   },
-
 
   /*  devServer: {
     https: {
@@ -317,6 +287,6 @@ export default defineNuxtConfig({
   }, */
 
   devtools: {
-    enabled: true
-  }
-});
+    enabled: true,
+  },
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "typecheck": "nuxt typecheck"
   },
   "devDependencies": {
+    "@distilled.cloud/nuxt": "^0.17.1",
     "@iconify-json/akar-icons": "^1.2.7",
     "@iconify-json/heroicons": "^1.2.3",
     "@iconify-json/ion": "^1.2.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,7 +35,7 @@
     "@vueuse/nuxt": "^13.9.0",
     "better-sqlite3": "^12.6.2",
     "nuxt": "catalog:",
-    "nuxt-umami": "^3.2.1",
+    "nuxt-umami": "https://github.com/bgervan/nuxt-umami/releases/download/v3.4.0-bg.2/nuxt-umami-3.4.0.tgz",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "typescript": "catalog:",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "nuxt build",
+    "build": "nuxt build --preset cloudflare_module",
     "dev": "nuxt dev",
     "dev-ssl": "set NODE_TLS_REJECT_UNAUTHORIZED=0&&nuxt dev",
     "generate": "nuxt generate",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,6 @@
 {
   "name": "web",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/server/routes/rss.xml.ts
+++ b/apps/web/server/routes/rss.xml.ts
@@ -3,6 +3,7 @@ import RSS from "rss";
 import { generateSlug } from "~/utils/format";
 import type { Article, Page, Recipe, SEO } from "~/types/strapiMeta";
 import { serverCmsFind } from "../utils/cms-fetch";
+import { getPublicSiteOrigin } from "../utils/site-url";
 
 function getSeoDescription(seo: SEO[] | SEO | undefined, seoMeta?: SEO) {
   if (seoMeta?.description) return seoMeta.description;
@@ -11,10 +12,11 @@ function getSeoDescription(seo: SEO[] | SEO | undefined, seoMeta?: SEO) {
 }
 
 export default defineEventHandler(async (event) => {
+  const siteOrigin = getPublicSiteOrigin(event);
   const feed = new RSS({
     title: "Journal du cuistot",
-    site_url: "https://journalducuistot.fr",
-    feed_url: `https://journalducuistot.fr/rss.xml`,
+    site_url: siteOrigin,
+    feed_url: `${siteOrigin}/rss.xml`,
   });
 
   const [pagesResponse, articlesResponse, recipesResponse] = await Promise.all([
@@ -39,7 +41,7 @@ export default defineEventHandler(async (event) => {
   for (const doc of pages) {
     feed.item({
       title: doc.title ?? "-",
-      url: `https://journalducuistot.fr${generateSlug(doc.slug ?? "", doc.parent)}`,
+      url: `${siteOrigin}${generateSlug(doc.slug ?? "", doc.parent)}`,
       date: doc.publishedAt ?? new Date().toISOString(),
       description: getSeoDescription(undefined, doc.seoMeta),
     });
@@ -47,7 +49,7 @@ export default defineEventHandler(async (event) => {
   for (const doc of articles) {
     feed.item({
       title: doc.title ?? "-",
-      url: `https://journalducuistot.fr/blog/${doc.category?.slug || "uncategorized"}/${doc.slug}`,
+      url: `${siteOrigin}/blog/${doc.category?.slug || "uncategorized"}/${doc.slug}`,
       date: doc.publishedAt ?? new Date().toISOString(),
       description: getSeoDescription(doc.seo, doc.seoMeta),
     });
@@ -55,7 +57,7 @@ export default defineEventHandler(async (event) => {
   for (const doc of recipes) {
     feed.item({
       title: doc.title ?? "-",
-      url: `https://journalducuistot.fr/recette/${doc.slug}`,
+      url: `${siteOrigin}/recette/${doc.slug}`,
       date: doc.publishedAt ?? new Date().toISOString(),
       description: getSeoDescription(doc.seo, doc.seoMeta),
     });

--- a/apps/web/server/utils/site-url.ts
+++ b/apps/web/server/utils/site-url.ts
@@ -1,0 +1,11 @@
+import type { H3Event } from 'h3'
+
+/** Canonical public site origin (no trailing slash) for RSS and absolute URLs. */
+export function getPublicSiteOrigin(event?: H3Event): string {
+  const config = useRuntimeConfig(event)
+  const raw =
+    (config.site?.url as string | undefined) ||
+    process.env.NUXT_PUBLIC_SITE_URL ||
+    'http://localhost:3000'
+  return raw.replace(/\/$/, '')
+}

--- a/infra/workers.ts
+++ b/infra/workers.ts
@@ -1,5 +1,5 @@
+import * as Alchemy from 'alchemy'
 import * as Cloudflare from 'alchemy/Cloudflare'
-import * as Command from 'alchemy/Command'
 import * as Output from 'alchemy/Output'
 import { Stage } from 'alchemy/Stage'
 import * as Config from 'effect/Config'
@@ -27,6 +27,20 @@ const CMS_WORKERS_CACHE = {
   crossVersionCache: true,
 } as const
 
+const NUXT_MEMO = {
+  include: [
+    'app/**',
+    'server/**',
+    'shared/**',
+    'public/**',
+    'exports.cloudflare.ts',
+    'nuxt.config.ts',
+    'app.config.ts',
+    'package.json',
+  ],
+  exclude: ['.data/**', 'coverage/**', '.nuxt/**', '.output/**', '.cache/**'],
+}
+
 export const workers = Effect.fn(function* (input: {
   DB: Cloudflare.D1.Database
   AiReadyDB: Cloudflare.D1.Database
@@ -35,19 +49,10 @@ export const workers = Effect.fn(function* (input: {
 }) {
   const stage = yield* Stage
   const isProd = stage === 'prod'
+  const isAlchemyDev = yield* Alchemy.ALCHEMY_DEV
   const prodCmsOrigin = `https://${PROD_CMS_HOST}`
   const cmsDomain = isProd ? PROD_CMS_HOST : undefined
   const webDomain = isProd ? PROD_WEB_HOST : undefined
-
-  const cmsBuild = yield* Command.Build('cms-build', {
-    command: 'pnpm --filter cms build',
-    cwd: '.',
-    outdir: 'apps/cms/.output',
-    memo: {
-      include: ['apps/cms/**', 'pnpm-lock.yaml', 'pnpm-workspace.yaml'],
-      exclude: ['apps/cms/.data', 'apps/cms/coverage', 'apps/cms/.nuxt'],
-    },
-  })
 
   // Provision AI Gateway (dashboard logs, caching, rate limits).
   // Nuxt CMS uses Workers AI binding + `CMS_AI_GATEWAY_ID` in `workers-ai-provider` (not Effect `QueryGateway`).
@@ -69,9 +74,15 @@ export const workers = Effect.fn(function* (input: {
   const strapiUrl = Config.string('STRAPI_URL').pipe(Config.withDefault(''))
   const strapiApiToken = Config.string('STRAPI_API_TOKEN').pipe(Config.withDefault(''))
 
-  const Cms = yield* Cloudflare.Worker('Cms', {
-    bundle: false,
-    main: 'apps/cms/.output/server/index.mjs',
+  // Website.Nuxt builds via @distilled.cloud/nuxt (cloudflare_module) and
+  // runs Nuxt's own dev server under `alchemy dev` with bindings on
+  // event.context.cloudflare — wrangler-free.
+  // @see https://alchemy.run/cloudflare/frontend/nuxt/
+  // Workflow class stays on nitro's exports.cloudflare.ts seam (no custom main).
+  // Workflows are not servable in Website.Nuxt local dev yet — omit the binding
+  // so the platform proxy can start; CMS uses processRunOnce fallback (see service.ts).
+  const Cms = yield* Cloudflare.Website.Nuxt('Cms', {
+    rootDir: 'apps/cms',
     domain: cmsDomain,
     cache: CMS_WORKERS_CACHE,
     env: {
@@ -82,7 +93,7 @@ export const workers = Effect.fn(function* (input: {
       CMS_AI_GATEWAY_ID: Config.string('CMS_AI_GATEWAY_ID').pipe(
         Config.withDefault(CMS_AI_GATEWAY_ID),
       ),
-      CONTENT_GENERATION: ContentGeneration,
+      ...(isAlchemyDev ? {} : { CONTENT_GENERATION: ContentGeneration }),
       NUXT_SESSION_PASSWORD: Config.string('NUXT_SESSION_PASSWORD'),
       NUXT_OG_IMAGE_SECRET: Config.string('NUXT_OG_IMAGE_SECRET').pipe(
         Config.withDefault(''),
@@ -94,14 +105,7 @@ export const workers = Effect.fn(function* (input: {
     },
     crons: [PUBLISH_CRON],
     compatibility: NODE_COMPAT,
-    assets: {
-      directory: 'apps/cms/.output/public',
-      hash: cmsBuild.hash,
-    },
-    dev: {
-      mode: 'external',
-      url: 'http://localhost:3001',
-    },
+    memo: NUXT_MEMO,
   })
 
   // Prod → custom CMS host; preview / local → Cms.url (workers.dev or alchemy.dev localhost).
@@ -131,31 +135,15 @@ export const workers = Effect.fn(function* (input: {
 
   const SkewProtection = yield* Cloudflare.KV.Namespace('WebSkewProtection', {})
 
-  const webBuild = yield* Command.Build('web-build', {
-    command: 'pnpm --filter web build',
-    cwd: '.',
-    outdir: 'apps/web/.output',
-    env: {
-      SKEW_PROTECTION_KV_NAMESPACE_ID: SkewProtection.namespaceId,
-      // Cloudflare Workers use routeRules ISR + KV bindings — not Vercel Redis.
-      REDIS_URL: '',
-      CMS_BASE_URL: cmsBaseUrl,
-      NUXT_PUBLIC_CMS_BASE_URL: cmsPublicUrl,
-      NUXT_OG_IMAGE_SECRET: ogImageSecret,
-      NUXT_PUBLIC_SITE_URL: siteUrl,
-      NUXT_PUBLIC_UMAMI_ID: umamiId,
-      // nuxt-umami module options read NUXT_UMAMI_ID at build time.
-      NUXT_UMAMI_ID: umamiId,
-    },
-    memo: {
-      include: ['apps/web/**', 'pnpm-lock.yaml', 'pnpm-workspace.yaml'],
-      exclude: ['apps/web/.nuxt', 'apps/web/.cache'],
-    },
-  })
+  // Deploy-time Nuxt overrides (merge over apps/web/nuxt.config.ts).
+  // Skew assets only when a Cloudflare token is present (same gate as before).
+  const skewBundleAssets = Boolean(process.env.CLOUDFLARE_API_TOKEN)
+  // Former Command.Build forced REDIS_URL='' so nuxt.config does not embed
+  // Vercel Redis into the Workers bundle (host `.env` still has REDIS_URL).
+  process.env.REDIS_URL = ''
 
-  const Web = yield* Cloudflare.Worker('Web', {
-    bundle: false,
-    main: 'apps/web/.output/server/index.mjs',
+  const Web = yield* Cloudflare.Website.Nuxt('Web', {
+    rootDir: 'apps/web',
     domain: webDomain,
     // Workers Cache intentionally OFF — see ADR-006 (static assets stay free).
     env: {
@@ -171,13 +159,26 @@ export const workers = Effect.fn(function* (input: {
       NUXT_UMAMI_ID: umamiId,
     },
     compatibility: WEB_NODE_COMPAT,
-    assets: {
-      directory: 'apps/web/.output/public',
-      hash: webBuild.hash,
-    },
-    dev: {
-      mode: 'external',
-      url: 'http://localhost:3000',
+    memo: NUXT_MEMO,
+    nuxt: {
+      site: {
+        url: siteUrl,
+      },
+      runtimeConfig: {
+        public: {
+          cmsBaseUrl: cmsPublicUrl,
+          apiBase: cmsPublicUrl,
+        },
+      },
+      umami: {
+        id: umamiId,
+      },
+      skewProtection: {
+        bundleAssets: skewBundleAssets,
+        storage: {
+          namespaceId: SkewProtection.namespaceId,
+        },
+      },
     },
   })
 

--- a/infra/workers.ts
+++ b/infra/workers.ts
@@ -10,6 +10,7 @@ import { CMS_AI_GATEWAY_ID } from '../apps/cms/shared/workers-ai-model.ts'
 /** Production custom domains (`stage === prod` only). Zone must exist on the Cloudflare account. */
 const PROD_WEB_HOST = 'journalducuistot.fr'
 const PROD_CMS_HOST = 'admin.journalducuistot.fr'
+const PROD_UMAMI_HOST = 'https://analytics.bertynboulikou.com'
 const CMS_DEV_PORT = 3001
 const WEB_DEV_PORT = 3000
 const CMS_ROOT_DIR = fileURLToPath(new URL('../apps/cms/', import.meta.url))
@@ -133,8 +134,9 @@ export const workers = Effect.fn(function* (input: {
     ? `https://${PROD_WEB_HOST}`
     : Config.string('NUXT_PUBLIC_SITE_URL').pipe(Config.withDefault('http://localhost:3000'))
   const ogImageSecret = Config.string('NUXT_OG_IMAGE_SECRET').pipe(Config.withDefault(''))
-  // Public analytics site id — prod only (preview/local stay without Umami).
+  // Umami — prod only (preview/local: no id/host → module stays in test mode).
   const umamiId = isProd ? '54df0335-b527-43b0-9087-35f6331c9bc7' : ''
+  const umamiHost = isProd ? PROD_UMAMI_HOST : ''
 
   const SkewProtection = yield* Cloudflare.KV.Namespace('WebSkewProtection', {})
 
@@ -162,8 +164,10 @@ export const workers = Effect.fn(function* (input: {
       NUXT_PUBLIC_SITE_URL: siteUrl,
       NUXT_OG_IMAGE_SECRET: ogImageSecret,
       STRAPI_URL: Config.string('STRAPI_URL').pipe(Config.withDefault('')),
-      NUXT_PUBLIC_UMAMI_ID: umamiId,
       NUXT_UMAMI_ID: umamiId,
+      ...(isProd
+        ? { NUXT_UMAMI_HOST: umamiHost }
+        : { NUXT_SITE_INDEXABLE: 'false' }),
     },
     compatibility: WEB_NODE_COMPAT,
     memo: NUXT_MEMO,
@@ -173,6 +177,7 @@ export const workers = Effect.fn(function* (input: {
       },
       site: {
         url: siteUrl,
+        ...(isProd ? {} : { indexable: false }),
       },
       runtimeConfig: {
         public: {
@@ -182,6 +187,7 @@ export const workers = Effect.fn(function* (input: {
       },
       umami: {
         id: umamiId,
+        ...(isProd ? { host: umamiHost } : {}),
       },
       skewProtection: {
         bundleAssets: skewBundleAssets,

--- a/infra/workers.ts
+++ b/infra/workers.ts
@@ -1,6 +1,7 @@
 import * as Alchemy from 'alchemy'
 import * as Cloudflare from 'alchemy/Cloudflare'
 import * as Output from 'alchemy/Output'
+import { fileURLToPath } from 'node:url'
 import { Stage } from 'alchemy/Stage'
 import * as Config from 'effect/Config'
 import * as Effect from 'effect/Effect'
@@ -9,6 +10,10 @@ import { CMS_AI_GATEWAY_ID } from '../apps/cms/shared/workers-ai-model.ts'
 /** Production custom domains (`stage === prod` only). Zone must exist on the Cloudflare account. */
 const PROD_WEB_HOST = 'journalducuistot.fr'
 const PROD_CMS_HOST = 'admin.journalducuistot.fr'
+const CMS_DEV_PORT = 3001
+const WEB_DEV_PORT = 3000
+const CMS_ROOT_DIR = fileURLToPath(new URL('../apps/cms/', import.meta.url))
+const WEB_ROOT_DIR = fileURLToPath(new URL('../apps/web/', import.meta.url))
 
 const NODE_COMPAT = {
   date: '2025-01-15',
@@ -64,9 +69,7 @@ export const workers = Effect.fn(function* (input: {
     collectLogs: true,
   })
 
-  const ContentGeneration = Cloudflare.Workflow<
-    { runId: string }
-  >('ContentGeneration', {
+  const ContentGeneration = Cloudflare.Workflow<{ runId: string }>('ContentGeneration', {
     className: 'ContentGenerationWorkflow',
   })
 
@@ -82,22 +85,32 @@ export const workers = Effect.fn(function* (input: {
   // Workflows are not servable in Website.Nuxt local dev yet — omit the binding
   // so the platform proxy can start; CMS uses processRunOnce fallback (see service.ts).
   const Cms = yield* Cloudflare.Website.Nuxt('Cms', {
-    rootDir: 'apps/cms',
+    rootDir: CMS_ROOT_DIR,
     domain: cmsDomain,
     cache: CMS_WORKERS_CACHE,
+    // Keep the Alchemy URL stable for local CMS tooling.
+    dev: {
+      port: CMS_DEV_PORT,
+      strictPort: true,
+    },
+    // @distilled.cloud/nuxt 0.17.1 normally asks Nuxt for port 0. The
+    // project patch forwards this override so Nuxt itself listens on 3001.
+    nuxt: {
+      devServer: {
+        port: CMS_DEV_PORT,
+      },
+    },
     env: {
       DB: input.DB,
       Media: input.Media,
       Cache: input.Cache,
       AI: Cloudflare.Workers.AI(),
       CMS_AI_GATEWAY_ID: Config.string('CMS_AI_GATEWAY_ID').pipe(
-        Config.withDefault(CMS_AI_GATEWAY_ID),
+        Config.withDefault(CMS_AI_GATEWAY_ID)
       ),
       ...(isAlchemyDev ? {} : { CONTENT_GENERATION: ContentGeneration }),
       NUXT_SESSION_PASSWORD: Config.string('NUXT_SESSION_PASSWORD'),
-      NUXT_OG_IMAGE_SECRET: Config.string('NUXT_OG_IMAGE_SECRET').pipe(
-        Config.withDefault(''),
-      ),
+      NUXT_OG_IMAGE_SECRET: Config.string('NUXT_OG_IMAGE_SECRET').pipe(Config.withDefault('')),
       STRAPI_URL: strapiUrl,
       NUXT_STRAPI_URL: strapiUrl,
       STRAPI_API_TOKEN: strapiApiToken,
@@ -110,26 +123,16 @@ export const workers = Effect.fn(function* (input: {
 
   // Prod → custom CMS host; preview / local → Cms.url (workers.dev or alchemy.dev localhost).
   const cmsOriginOverride = yield* Config.string('CMS_BASE_URL').pipe(Config.option)
-  const cmsPublicOverride = yield* Config.string('NUXT_PUBLIC_CMS_BASE_URL').pipe(
-    Config.option,
-  )
-  const cmsWorkerOrigin = Output.map(
-    Cms.url,
-    (url) => url ?? 'http://localhost:3001',
-  )
+  const cmsPublicOverride = yield* Config.string('NUXT_PUBLIC_CMS_BASE_URL').pipe(Config.option)
+  const cmsWorkerOrigin = Output.map(Cms.url, (url) => url ?? 'http://localhost:3001')
   const defaultCmsOrigin = isProd ? prodCmsOrigin : cmsWorkerOrigin
-  const cmsBaseUrl =
-    cmsOriginOverride._tag === 'Some' ? cmsOriginOverride.value : defaultCmsOrigin
+  const cmsBaseUrl = cmsOriginOverride._tag === 'Some' ? cmsOriginOverride.value : defaultCmsOrigin
   const cmsPublicUrl =
     cmsPublicOverride._tag === 'Some' ? cmsPublicOverride.value : defaultCmsOrigin
   const siteUrl = isProd
     ? `https://${PROD_WEB_HOST}`
-    : Config.string('NUXT_PUBLIC_SITE_URL').pipe(
-      Config.withDefault('http://localhost:3000'),
-    )
-  const ogImageSecret = Config.string('NUXT_OG_IMAGE_SECRET').pipe(
-    Config.withDefault(''),
-  )
+    : Config.string('NUXT_PUBLIC_SITE_URL').pipe(Config.withDefault('http://localhost:3000'))
+  const ogImageSecret = Config.string('NUXT_OG_IMAGE_SECRET').pipe(Config.withDefault(''))
   // Public analytics site id — prod only (preview/local stay without Umami).
   const umamiId = isProd ? '54df0335-b527-43b0-9087-35f6331c9bc7' : ''
 
@@ -143,9 +146,13 @@ export const workers = Effect.fn(function* (input: {
   process.env.REDIS_URL = ''
 
   const Web = yield* Cloudflare.Website.Nuxt('Web', {
-    rootDir: 'apps/web',
+    rootDir: WEB_ROOT_DIR,
     domain: webDomain,
     // Workers Cache intentionally OFF — see ADR-006 (static assets stay free).
+    dev: {
+      port: WEB_DEV_PORT,
+      strictPort: true,
+    },
     env: {
       Cache: input.Cache,
       AI_READY_DB: input.AiReadyDB,
@@ -161,6 +168,9 @@ export const workers = Effect.fn(function* (input: {
     compatibility: WEB_NODE_COMPAT,
     memo: NUXT_MEMO,
     nuxt: {
+      devServer: {
+        port: WEB_DEV_PORT,
+      },
       site: {
         url: siteUrl,
       },

--- a/infra/workers.ts
+++ b/infra/workers.ts
@@ -7,10 +7,7 @@ import * as Config from 'effect/Config'
 import * as Effect from 'effect/Effect'
 import { CMS_AI_GATEWAY_ID } from '../apps/cms/shared/workers-ai-model.ts'
 
-/** Production custom domains (`stage === prod` only). Zone must exist on the Cloudflare account. */
-const PROD_WEB_HOST = 'journalducuistot.fr'
-const PROD_CMS_HOST = 'admin.journalducuistot.fr'
-const PROD_UMAMI_HOST = 'https://analytics.bertynboulikou.com'
+/** Production custom domains (`stage === prod` only). Set via env — not committed. */
 const CMS_DEV_PORT = 3001
 const WEB_DEV_PORT = 3000
 const CMS_ROOT_DIR = fileURLToPath(new URL('../apps/cms/', import.meta.url))
@@ -56,9 +53,13 @@ export const workers = Effect.fn(function* (input: {
   const stage = yield* Stage
   const isProd = stage === 'prod'
   const isAlchemyDev = yield* Alchemy.ALCHEMY_DEV
-  const prodCmsOrigin = `https://${PROD_CMS_HOST}`
-  const cmsDomain = isProd ? PROD_CMS_HOST : undefined
-  const webDomain = isProd ? PROD_WEB_HOST : undefined
+  const prodWebHost = yield* Config.string('PROD_WEB_HOST').pipe(Config.withDefault(''))
+  const prodCmsHost = yield* Config.string('PROD_CMS_HOST').pipe(Config.withDefault(''))
+  const normalizeHost = (value: string) =>
+    value.replace(/^https?:\/\//, '').replace(/\/$/, '')
+  const prodCmsOrigin = prodCmsHost ? `https://${normalizeHost(prodCmsHost)}` : ''
+  const cmsDomain = isProd && prodCmsHost ? normalizeHost(prodCmsHost) : undefined
+  const webDomain = isProd && prodWebHost ? normalizeHost(prodWebHost) : undefined
 
   // Provision AI Gateway (dashboard logs, caching, rate limits).
   // Nuxt CMS uses Workers AI binding + `CMS_AI_GATEWAY_ID` in `workers-ai-provider` (not Effect `QueryGateway`).
@@ -130,13 +131,20 @@ export const workers = Effect.fn(function* (input: {
   const cmsBaseUrl = cmsOriginOverride._tag === 'Some' ? cmsOriginOverride.value : defaultCmsOrigin
   const cmsPublicUrl =
     cmsPublicOverride._tag === 'Some' ? cmsPublicOverride.value : defaultCmsOrigin
-  const siteUrl = isProd
-    ? `https://${PROD_WEB_HOST}`
-    : Config.string('NUXT_PUBLIC_SITE_URL').pipe(Config.withDefault('http://localhost:3000'))
+  const siteUrlFromEnv = yield* Config.string('NUXT_PUBLIC_SITE_URL').pipe(
+    Config.withDefault('http://localhost:3000'),
+  )
+  const siteUrl =
+    isProd && prodWebHost
+      ? `https://${normalizeHost(prodWebHost)}`
+      : siteUrlFromEnv
   const ogImageSecret = Config.string('NUXT_OG_IMAGE_SECRET').pipe(Config.withDefault(''))
-  // Umami — prod only (preview/local: no id/host → module stays in test mode).
-  const umamiId = isProd ? '54df0335-b527-43b0-9087-35f6331c9bc7' : ''
-  const umamiHost = isProd ? PROD_UMAMI_HOST : ''
+  const umamiId = isProd
+    ? yield* Config.string('NUXT_UMAMI_ID').pipe(Config.withDefault(''))
+    : ''
+  const umamiHost = isProd
+    ? yield* Config.string('NUXT_UMAMI_HOST').pipe(Config.withDefault(''))
+    : ''
 
   const SkewProtection = yield* Cloudflare.KV.Namespace('WebSkewProtection', {})
 
@@ -165,9 +173,8 @@ export const workers = Effect.fn(function* (input: {
       NUXT_OG_IMAGE_SECRET: ogImageSecret,
       STRAPI_URL: Config.string('STRAPI_URL').pipe(Config.withDefault('')),
       NUXT_UMAMI_ID: umamiId,
-      ...(isProd
-        ? { NUXT_UMAMI_HOST: umamiHost }
-        : { NUXT_SITE_INDEXABLE: 'false' }),
+      ...(isProd && umamiHost ? { NUXT_UMAMI_HOST: umamiHost } : {}),
+      ...(isProd ? {} : { NUXT_SITE_INDEXABLE: 'false' }),
     },
     compatibility: WEB_NODE_COMPAT,
     memo: NUXT_MEMO,

--- a/package.json
+++ b/package.json
@@ -32,10 +32,11 @@
   },
   "packageManager": "pnpm@10.33.4",
   "devDependencies": {
-    "@cloudflare/workers-types": "^5.20260712.1",
+    "@cloudflare/workers-types": "^5.20260804.1",
     "@effect/platform-node": "4.0.0-beta.102",
+    "@effect/sql-mysql2": "4.0.0-beta.102",
     "@effect/sql-pg": "4.0.0-beta.102",
-    "alchemy": "2.0.0-beta.67",
+    "alchemy": "catalog:",
     "drizzle-kit": "catalog:",
     "drizzle-orm": "catalog:",
     "effect": "4.0.0-beta.102",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "packageManager": "pnpm@10.33.4",
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260804.1",
+    "@distilled.cloud/nuxt": "^0.17.1",
     "@effect/platform-node": "4.0.0-beta.102",
     "@effect/sql-mysql2": "4.0.0-beta.102",
     "@effect/sql-pg": "4.0.0-beta.102",
@@ -43,7 +44,6 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "nuxt": "^4.5.0",
-    "wrangler": "^4.110.0"
+    "nuxt": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "journalducuistot",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {

--- a/patches/@distilled.cloud__nuxt@0.17.1.patch
+++ b/patches/@distilled.cloud__nuxt@0.17.1.patch
@@ -1,0 +1,73 @@
+diff --git a/dist/source.js b/dist/source.js
+index eadb13b14ebe3d4c3c7ab410fd8c825bec7c7ffa..bcf7ce29e84506ad74bbd9498d1cda8e81a7784e 100644
+--- a/dist/source.js
++++ b/dist/source.js
+@@ -283,6 +283,21 @@ const resolveDevEnvOverrides = (env) => {
+     }
+     return out;
+ };
++/**
++ * The framework adapter normally asks Nuxt for an ephemeral port so multiple
++ * Website.Nuxt resources can start without coordination. Allow a Nuxt
++ * `devServer.port` override when a monorepo needs stable local URLs.
++ */
++const resolveDevPort = (options) => {
++    const devServer = options.nuxt?.devServer;
++    if (devServer !== null &&
++        typeof devServer === "object" &&
++        "port" in devServer &&
++        typeof devServer.port === "number") {
++        return devServer.port;
++    }
++    return 0;
++};
+ export const makeNuxtSource = (options) => {
+     const rootDir = NodePath.resolve(options.rootDir ?? process.cwd());
+     const frameworkOptions = (ctx, dev) => ({
+@@ -353,7 +368,7 @@ export const makeNuxtSource = (options) => {
+                 services: ctx.runtimeContext,
+             }));
+             const server = yield* framework
+-                .dev({ root: rootDir, port: 0 })
++                .dev({ root: rootDir, port: resolveDevPort(options) })
+                 .pipe(Effect.mapError(wrapFrameworkError));
+             return {
+                 mode: "server",
+diff --git a/src/source.ts b/src/source.ts
+index 42b9eeab9d0d68aa83e4b75162f494e0a5fee38a..93aef318f28edb69a271e77cd6bcff0c48e3c6be 100644
+--- a/src/source.ts
++++ b/src/source.ts
+@@ -507,6 +507,24 @@ const resolveDevEnvOverrides = (
+   return out;
+ };
+ 
++/**
++ * The framework adapter normally asks Nuxt for an ephemeral port so multiple
++ * Website.Nuxt resources can start without coordination. Allow a Nuxt
++ * `devServer.port` override when a monorepo needs stable local URLs.
++ */
++const resolveDevPort = (options: NuxtSourceOptions): number => {
++  const devServer = options.nuxt?.devServer;
++  if (
++    devServer !== null &&
++    typeof devServer === "object" &&
++    "port" in devServer &&
++    typeof devServer.port === "number"
++  ) {
++    return devServer.port;
++  }
++  return 0;
++};
++
+ export const makeNuxtSource = (options: NuxtSourceOptions): SourceProvider => {
+   const rootDir = NodePath.resolve(options.rootDir ?? process.cwd());
+   const frameworkOptions = (ctx: SourceContext, dev?: NuxtOptions["dev"]): NuxtOptions => ({
+@@ -595,7 +613,7 @@ export const makeNuxtSource = (options: NuxtSourceOptions): SourceProvider => {
+         }),
+       );
+       const server = yield* framework
+-        .dev({ root: rootDir, port: 0 })
++        .dev({ root: rootDir, port: resolveDevPort(options) })
+         .pipe(Effect.mapError(wrapFrameworkError));
+       return {
+         mode: "server",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@nuxt/eslint-plugin':
-      specifier: ^1.15.2
-      version: 1.15.2
     alchemy:
       specifier: 2.0.0-beta.68
       version: 2.0.0-beta.68
@@ -18,24 +15,6 @@ catalogs:
     drizzle-orm:
       specifier: 1.0.0-rc.4
       version: 1.0.0-rc.4
-    nuxt:
-      specifier: ^4.4.5
-      version: 4.5.0
-    oxfmt:
-      specifier: ^0.58.0
-      version: 0.58.0
-    oxlint:
-      specifier: ^1.73.0
-      version: 1.73.0
-    vitest:
-      specifier: ^4.1.6
-      version: 4.1.6
-    vue-tsc:
-      specifier: ^3.2.9
-      version: 3.2.9
-    zod:
-      specifier: latest
-      version: 4.4.3
 
 overrides:
   effect: 4.0.0-beta.102
@@ -44,20 +23,25 @@ overrides:
   '@effect/sql-pg': 4.0.0-beta.102
   typescript: 6.0.3
 
+patchedDependencies:
+  '@distilled.cloud/nuxt@0.17.1':
+    hash: 70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe
+    path: patches/@distilled.cloud__nuxt@0.17.1.patch
+
 importers:
 
   .:
     dependencies:
       nuxt:
         specifier: ^4.5.0
-        version: 4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe)
-      wrangler:
-        specifier: ^4.110.0
-        version: 4.110.0(@cloudflare/workers-types@5.20260804.1)
+        version: 4.5.0(90c8833e38f8aa1b67239bf44a487755)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^5.20260804.1
         version: 5.20260804.1
+      '@distilled.cloud/nuxt':
+        specifier: ^0.17.1
+        version: 0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(90c8833e38f8aa1b67239bf44a487755))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1)
@@ -69,7 +53,7 @@ importers:
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.68(74327ec9d35598bd395fb5ad2aa58efd)
+        version: 2.0.0-beta.68(e2552511f13d9432f311a03b36fac850)
       drizzle-kit:
         specifier: 'catalog:'
         version: 1.0.0-rc.4
@@ -135,7 +119,7 @@ importers:
         version: 1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3)
       evlog:
         specifier: ^2.22.0
-        version: 2.22.0(e8068d4b4d0cdefcb4c252f2af1431ef)
+        version: 2.22.0(5d729d034b220b5fa5dc3773f09c9272)
       exifr:
         specifier: ^7.1.3
         version: 7.1.3
@@ -166,7 +150,7 @@ importers:
         version: 5.20260712.1
       '@distilled.cloud/nuxt':
         specifier: ^0.17.1
-        version: 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@nuxt/eslint-plugin':
         specifier: 'catalog:'
         version: 1.15.2(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
@@ -254,7 +238,7 @@ importers:
     devDependencies:
       '@distilled.cloud/nuxt':
         specifier: ^0.17.1
-        version: 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@iconify-json/akar-icons':
         specifier: ^1.2.7
         version: 1.2.7
@@ -685,10 +669,6 @@ packages:
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
     engines: {node: '>=18.0.0'}
 
-  '@cloudflare/kv-asset-handler@0.5.0':
-    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
-    engines: {node: '>=22.0.0'}
-
   '@cloudflare/unenv-preset@2.16.1':
     resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
     peerDependencies:
@@ -704,8 +684,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20260708.1':
-    resolution: {integrity: sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg==}
+  '@cloudflare/workerd-darwin-64@1.20260801.1':
+    resolution: {integrity: sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -716,8 +696,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260708.1':
-    resolution: {integrity: sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA==}
+  '@cloudflare/workerd-darwin-arm64@1.20260801.1':
+    resolution: {integrity: sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -728,8 +708,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20260708.1':
-    resolution: {integrity: sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA==}
+  '@cloudflare/workerd-linux-64@1.20260801.1':
+    resolution: {integrity: sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -740,8 +720,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260708.1':
-    resolution: {integrity: sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA==}
+  '@cloudflare/workerd-linux-arm64@1.20260801.1':
+    resolution: {integrity: sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -752,8 +732,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20260708.1':
-    resolution: {integrity: sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA==}
+  '@cloudflare/workerd-windows-64@1.20260801.1':
+    resolution: {integrity: sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -781,10 +761,6 @@ packages:
         optional: true
       shiki:
         optional: true
-
-  '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
 
   '@devframes/hub@0.5.4':
     resolution: {integrity: sha512-NZs5RFuNb6tjQd2JBsRYQT+OqE+z16Kg9/72HG4k+uJdzK90sAGtAjOwK8bsvav/9l85KGx4agfkgxnfbl313w==}
@@ -1904,9 +1880,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@jridgewell/trace-mapping@0.3.9':
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@js-temporal/polyfill@0.5.1':
     resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
@@ -3057,9 +3030,6 @@ packages:
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
-
-  '@poppinss/dumper@0.6.5':
-    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
 
   '@poppinss/dumper@0.7.0':
     resolution: {integrity: sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==}
@@ -4812,9 +4782,6 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  blake3-wasm@2.1.5:
-    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
-
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -5054,10 +5021,6 @@ packages:
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
-
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
 
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
@@ -6973,11 +6936,6 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  miniflare@4.20260708.1:
-    resolution: {integrity: sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA==}
-    engines: {node: '>=22.0.0'}
-    hasBin: true
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -7544,9 +7502,6 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
-
-  path-to-regexp@6.3.0:
-    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -9163,8 +9118,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20260708.1:
-    resolution: {integrity: sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w==}
+  workerd@1.20260801.1:
+    resolution: {integrity: sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -9182,16 +9137,6 @@ packages:
       '@ai-sdk/google':
         optional: true
       '@ai-sdk/openai':
-        optional: true
-
-  wrangler@4.110.0:
-    resolution: {integrity: sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==}
-    engines: {node: '>=22.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@cloudflare/workers-types': ^5.20260708.1
-    peerDependenciesMeta:
-      '@cloudflare/workers-types':
         optional: true
 
   wrap-ansi@7.0.0:
@@ -9299,9 +9244,6 @@ packages:
 
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
-
-  youch@4.1.0-beta.10:
-    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   youch@4.1.1:
     resolution: {integrity: sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==}
@@ -9834,42 +9776,40 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
-  '@cloudflare/kv-asset-handler@0.5.0': {}
-
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260708.1
+      workerd: 1.20260801.1
 
   '@cloudflare/workerd-darwin-64@1.20260704.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260708.1':
+  '@cloudflare/workerd-darwin-64@1.20260801.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260704.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260708.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260801.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260704.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260708.1':
+  '@cloudflare/workerd-linux-64@1.20260801.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260704.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260708.1':
+  '@cloudflare/workerd-linux-arm64@1.20260801.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260704.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260708.1':
+  '@cloudflare/workerd-windows-64@1.20260801.1':
     optional: true
 
   '@cloudflare/workers-types@5.20260712.1': {}
@@ -9882,10 +9822,6 @@ snapshots:
     dependencies:
       comark: 0.5.1
       vue: 3.5.40(typescript@6.0.3)
-
-  '@cspotcode/source-map-support@0.8.1':
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
 
   '@devframes/hub@0.5.4(devframe@0.5.4(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -9929,9 +9865,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@distilled.cloud/cloudflare-rolldown-plugin@0.16.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)':
+  '@distilled.cloud/cloudflare-rolldown-plugin@0.16.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260801.1)':
     dependencies:
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)
       magic-string: 0.30.21
       unenv: 2.0.0-rc.24
     optionalDependencies:
@@ -9974,10 +9910,10 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.16.0(@distilled.cloud/cloudflare-runtime@0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102))(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)':
+  '@distilled.cloud/cloudflare-vite-plugin@0.16.0(@distilled.cloud/cloudflare-runtime@0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102))(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260801.1)':
     dependencies:
       '@distilled.cloud/cloudflare': 1.0.0-rc.2
-      '@distilled.cloud/cloudflare-rolldown-plugin': 0.16.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)
+      '@distilled.cloud/cloudflare-rolldown-plugin': 0.16.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260801.1)
       '@distilled.cloud/cloudflare-runtime': 0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
       effect: 4.0.0-beta.102
       vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
@@ -10016,7 +9952,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@distilled.cloud/nuxt@0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@distilled.cloud/nuxt@0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@distilled.cloud/cloudflare-runtime': 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
       '@distilled.cloud/framework-core': 0.17.1(effect@4.0.0-beta.102)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -10034,7 +9970,25 @@ snapshots:
       - supports-color
       - vite
 
-  '@distilled.cloud/nuxt@0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@distilled.cloud/nuxt@0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(90c8833e38f8aa1b67239bf44a487755))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@distilled.cloud/cloudflare-runtime': 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
+      '@distilled.cloud/framework-core': 0.17.1(effect@4.0.0-beta.102)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      effect: 4.0.0-beta.102
+      fast-glob: 3.3.3
+    optionalDependencies:
+      nuxt: 4.5.0(90c8833e38f8aa1b67239bf44a487755)
+    transitivePeerDependencies:
+      - '@distilled.cloud/cloudflare'
+      - '@effect/platform-bun'
+      - '@effect/platform-node'
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+      - vite
+
+  '@distilled.cloud/nuxt@0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@distilled.cloud/cloudflare-runtime': 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
       '@distilled.cloud/framework-core': 0.17.1(effect@4.0.0-beta.102)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -10816,11 +10770,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jridgewell/trace-mapping@0.3.9':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
-
   '@js-temporal/polyfill@0.5.1':
     dependencies:
       jsbi: 4.3.2
@@ -11094,18 +11043,6 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/devtools-kit@3.2.4(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
-    dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      execa: 8.0.1
-      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
   '@nuxt/devtools-kit@3.2.4(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -11140,51 +11077,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.1
       semver: 7.8.5
-
-  '@nuxt/devtools@3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
-    dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      '@nuxt/devtools-wizard': 3.2.4
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@vue/devtools-core': 8.1.2(vue@3.5.40(typescript@6.0.3))
-      '@vue/devtools-kit': 8.1.5
-      birpc: 4.0.0
-      consola: 3.4.2
-      destr: 2.0.5
-      error-stack-parser-es: 1.0.5
-      execa: 8.0.1
-      fast-npm-meta: 1.5.1
-      get-port-please: 3.2.0
-      hookable: 6.1.1
-      image-meta: 0.2.2
-      is-installed-globally: 1.0.0
-      launch-editor: 2.13.2
-      local-pkg: 1.2.1
-      magicast: 0.5.3
-      nypm: 0.6.8
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.1
-      semver: 7.8.5
-      simple-git: 3.36.0
-      sirv: 3.0.2
-      structured-clone-es: 2.0.0
-      tinyglobby: 0.2.17
-      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      vite-plugin-vue-tracer: 1.4.0(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-      which: 6.0.1
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - magic-string
-      - oxc-parser
-      - rolldown
-      - supports-color
-      - unplugin
-      - utf-8-validate
-      - vue
 
   '@nuxt/devtools@3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
@@ -11479,36 +11371,6 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))':
-    dependencies:
-      c12: 3.3.4(magicast@0.5.3)
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      errx: 0.1.0
-      exsolve: 1.1.0
-      ignore: 7.0.6
-      jiti: 2.7.0
-      klona: 2.0.6
-      mlly: 1.8.2
-      nostics: 1.2.0
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      rc9: 3.0.1
-      scule: 1.3.0
-      semver: 7.8.5
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
   '@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))':
     dependencies:
       c12: 3.3.4(magicast@0.5.3)
@@ -11709,10 +11571,10 @@ snapshots:
       - webpack
       - xml2js
 
-  '@nuxt/nitro-server@4.5.0(e01bd71ada403ae072a54d3bc61413fc)':
+  '@nuxt/nitro-server@4.5.0(b91ba14303c75dc2fd3391cc3ccd1e2c)':
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@vue/shared': 3.5.40
       consola: 3.4.2
@@ -11728,14 +11590,14 @@ snapshots:
       mocked-exports: 0.1.1
       nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       nostics: 1.2.0
-      nuxt: 4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe)
+      nuxt: 4.5.0(90c8833e38f8aa1b67239bf44a487755)
       nypm: 0.6.8
       ohash: 2.0.11
       pathe: 2.0.3
       rou3: 0.9.1
       std-env: 4.2.0
       ufo: 1.6.4
-      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
       vue: 3.5.40(typescript@6.0.3)
       vue-bundle-renderer: 2.3.1
@@ -11801,15 +11663,6 @@ snapshots:
       nostics: 1.2.0
       pathe: 2.0.3
       pkg-types: 2.3.1
-      std-env: 4.2.0
-
-  '@nuxt/telemetry@2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))':
-    dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      citty: 0.2.2
-      consola: 3.4.2
-      ofetch: 2.0.0-alpha.3
-      rc9: 3.0.1
       std-env: 4.2.0
 
   '@nuxt/telemetry@2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))':
@@ -11932,8 +11785,8 @@ snapshots:
       typescript: 6.0.3
       ufo: 1.6.4
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3)))
-      unplugin-vue-components: 32.1.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3)))
+      unplugin-vue-components: 32.1.0(@nuxt/kit@4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       vaul-vue: 0.4.1(reka-ui@2.9.10(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
       vue-component-type-helpers: 3.3.7
     optionalDependencies:
@@ -12052,9 +11905,9 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe))(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(90c8833e38f8aa1b67239bf44a487755))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 5.1.6(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       autoprefixer: 10.5.4(postcss@8.5.20)
@@ -12069,7 +11922,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe)
+      nuxt: 4.5.0(90c8833e38f8aa1b67239bf44a487755)
       nypm: 0.6.8
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -12087,7 +11940,7 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
       rolldown: 1.2.0
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.4)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.4)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -12731,12 +12584,6 @@ snapshots:
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
-
-  '@poppinss/dumper@0.6.5':
-    dependencies:
-      '@poppinss/colors': 4.1.6
-      '@sindresorhus/is': 7.1.0
-      supports-color: 10.2.2
 
   '@poppinss/dumper@0.7.0':
     dependencies:
@@ -14277,7 +14124,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  alchemy@2.0.0-beta.68(74327ec9d35598bd395fb5ad2aa58efd):
+  alchemy@2.0.0-beta.68(e2552511f13d9432f311a03b36fac850):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1081.0
@@ -14285,9 +14132,9 @@ snapshots:
       '@distilled.cloud/aws': 1.0.0-rc.2(effect@4.0.0-beta.102)
       '@distilled.cloud/axiom': 1.0.0-rc.2
       '@distilled.cloud/cloudflare': 1.0.0-rc.2
-      '@distilled.cloud/cloudflare-rolldown-plugin': 0.16.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)
+      '@distilled.cloud/cloudflare-rolldown-plugin': 0.16.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260801.1)
       '@distilled.cloud/cloudflare-runtime': 0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
-      '@distilled.cloud/cloudflare-vite-plugin': 0.16.0(@distilled.cloud/cloudflare-runtime@0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102))(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)
+      '@distilled.cloud/cloudflare-vite-plugin': 0.16.0(@distilled.cloud/cloudflare-runtime@0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102))(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260801.1)
       '@distilled.cloud/core': 1.0.0-rc.2(effect@4.0.0-beta.102)
       '@distilled.cloud/neon': 1.0.0-rc.2
       '@distilled.cloud/planetscale': 1.0.0-rc.2
@@ -14514,8 +14361,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  blake3-wasm@2.1.5: {}
-
   boolbase@1.0.0: {}
 
   bowser@2.14.1: {}
@@ -14740,8 +14585,6 @@ snapshots:
   cookie-es@2.0.1: {}
 
   cookie-es@3.1.1: {}
-
-  cookie@1.1.1: {}
 
   copy-anything@3.0.5:
     dependencies:
@@ -15557,9 +15400,9 @@ snapshots:
 
   eventsource-parser@3.1.0: {}
 
-  evlog@2.22.0(e8068d4b4d0cdefcb4c252f2af1431ef):
+  evlog@2.22.0(5d729d034b220b5fa5dc3773f09c9272):
     optionalDependencies:
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       ai: 7.0.48(zod@4.4.3)
       h3: 1.15.11
       hono: 4.11.4
@@ -16617,18 +16460,6 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  miniflare@4.20260708.1:
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.34.5
-      undici: 7.28.0
-      workerd: 1.20260708.1
-      ws: 8.21.0
-      youch: 4.1.0-beta.10
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -17645,16 +17476,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe):
+  nuxt@4.5.0(90c8833e38f8aa1b67239bf44a487755):
     dependencies:
       '@dxup/nuxt': 0.5.3(esbuild@0.28.1)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.0)(cac@6.7.14)(magicast@0.5.3)
-      '@nuxt/devtools': 3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.0(e01bd71ada403ae072a54d3bc61413fc)
+      '@nuxt/devtools': 3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxt/nitro-server': 4.5.0(b91ba14303c75dc2fd3391cc3ccd1e2c)
       '@nuxt/schema': 4.5.0
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe))(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))
+      '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(90c8833e38f8aa1b67239bf44a487755))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
       '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@vue/shared': 3.5.40
       chokidar: 5.0.0
@@ -17697,7 +17528,7 @@ snapshots:
       ufo: 1.6.4
       ultrahtml: 1.7.0
       uncrypto: 0.1.3
-      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       undici: 8.7.0
       unhead: 3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -18205,8 +18036,6 @@ snapshots:
     dependencies:
       lru-cache: 11.3.6
       minipass: 7.1.3
-
-  path-to-regexp@6.3.0: {}
 
   pathe@1.1.2: {}
 
@@ -18811,17 +18640,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.2.0
       '@rolldown/binding-win32-arm64-msvc': 1.2.0
       '@rolldown/binding-win32-x64-msvc': 1.2.0
-
-  rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.4):
-    dependencies:
-      open: 11.0.0
-      picomatch: 4.0.5
-      source-map: 0.7.6
-      yargs: 18.0.0
-    optionalDependencies:
-      rolldown: 1.1.5
-      rollup: 4.60.4
-    optional: true
 
   rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4):
     dependencies:
@@ -19457,13 +19275,6 @@ snapshots:
       rolldown: 1.2.0
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
 
-  unctx@3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))):
-    optionalDependencies:
-      magic-string: 1.0.0
-      oxc-parser: 0.140.0
-      rolldown: 1.2.0
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-
   unctx@3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))):
     optionalDependencies:
       magic-string: 1.0.0
@@ -19564,7 +19375,7 @@ snapshots:
 
   universal-user-agent@7.0.3: {}
 
-  unplugin-auto-import@21.0.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3))):
+  unplugin-auto-import@21.0.0(@nuxt/kit@4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3))):
     dependencies:
       local-pkg: 1.2.1
       magic-string: 0.30.21
@@ -19573,7 +19384,7 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.2
     optionalDependencies:
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
 
   unplugin-utils@0.3.2:
@@ -19581,7 +19392,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.5
 
-  unplugin-vue-components@32.1.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)):
+  unplugin-vue-components@32.1.0(@nuxt/kit@4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)):
     dependencies:
       chokidar: 5.0.0
       local-pkg: 1.2.1
@@ -19594,7 +19405,7 @@ snapshots:
       unplugin-utils: 0.3.2
       vue: 3.5.40(typescript@6.0.3)
     optionalDependencies:
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -19612,18 +19423,6 @@ snapshots:
       acorn: 8.16.0
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
-
-  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.5
-      webpack-virtual-modules: 0.6.2
-    optionalDependencies:
-      esbuild: 0.28.1
-      rolldown: 1.1.5
-      rollup: 4.60.4
-      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
-    optional: true
 
   unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
@@ -19796,23 +19595,6 @@ snapshots:
       oxlint: 1.73.0
       typescript: 6.0.3
       vue-tsc: 3.2.9(typescript@6.0.3)
-
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
-    dependencies:
-      ansis: 4.2.0
-      debug: 4.4.3
-      error-stack-parser-es: 1.0.5
-      ohash: 2.0.11
-      open: 10.2.0
-      perfect-debounce: 2.1.0
-      sirv: 3.0.2
-      unplugin-utils: 0.3.2
-      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
-      vite-dev-rpc: 1.1.0(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-    optionalDependencies:
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-    transitivePeerDependencies:
-      - supports-color
 
   vite-plugin-inspect@11.3.3(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
@@ -20046,35 +19828,19 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260704.1
       '@cloudflare/workerd-windows-64': 1.20260704.1
 
-  workerd@1.20260708.1:
+  workerd@1.20260801.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260708.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260708.1
-      '@cloudflare/workerd-linux-64': 1.20260708.1
-      '@cloudflare/workerd-linux-arm64': 1.20260708.1
-      '@cloudflare/workerd-windows-64': 1.20260708.1
+      '@cloudflare/workerd-darwin-64': 1.20260801.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260801.1
+      '@cloudflare/workerd-linux-64': 1.20260801.1
+      '@cloudflare/workerd-linux-arm64': 1.20260801.1
+      '@cloudflare/workerd-windows-64': 1.20260801.1
+    optional: true
 
   workers-ai-provider@4.0.0(@ai-sdk/provider@4.0.4)(ai@7.0.48(zod@4.4.3)):
     dependencies:
       '@ai-sdk/provider': 4.0.4
       ai: 7.0.48(zod@4.4.3)
-
-  wrangler@4.110.0(@cloudflare/workers-types@5.20260804.1):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)
-      blake3-wasm: 2.1.5
-      esbuild: 0.28.1
-      miniflare: 4.20260708.1
-      path-to-regexp: 6.3.0
-      unenv: 2.0.0-rc.24
-      workerd: 1.20260708.1
-    optionalDependencies:
-      '@cloudflare/workers-types': 5.20260804.1
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -20172,14 +19938,6 @@ snapshots:
     dependencies:
       '@poppinss/exception': 1.2.2
       error-stack-parser-es: 1.0.5
-
-  youch@4.1.0-beta.10:
-    dependencies:
-      '@poppinss/colors': 4.1.6
-      '@poppinss/dumper': 0.6.5
-      '@speed-highlight/core': 1.2.15
-      cookie: 1.1.1
-      youch-core: 0.3.3
 
   youch@4.1.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@nuxt/eslint-plugin':
       specifier: ^1.15.2
       version: 1.15.2
+    alchemy:
+      specifier: 2.0.0-beta.68
+      version: 2.0.0-beta.68
     drizzle-kit:
       specifier: 1.0.0-rc.4
       version: 1.0.0-rc.4
@@ -47,29 +50,32 @@ importers:
     dependencies:
       nuxt:
         specifier: ^4.5.0
-        version: 4.5.0(9e2c98569c50f8e722d2aef5b4a88ea0)
+        version: 4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe)
       wrangler:
         specifier: ^4.110.0
-        version: 4.110.0(@cloudflare/workers-types@5.20260712.1)
+        version: 4.110.0(@cloudflare/workers-types@5.20260804.1)
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^5.20260712.1
-        version: 5.20260712.1
+        specifier: ^5.20260804.1
+        version: 5.20260804.1
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1)
+      '@effect/sql-mysql2':
+        specifier: 4.0.0-beta.102
+        version: 4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102)
       '@effect/sql-pg':
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)
       alchemy:
-        specifier: 2.0.0-beta.67
-        version: 2.0.0-beta.67(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@types/node@22.18.10)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(effect@4.0.0-beta.102)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.6)(workerd@1.20260708.1)(ws@8.21.0)
+        specifier: 'catalog:'
+        version: 2.0.0-beta.68(74327ec9d35598bd395fb5ad2aa58efd)
       drizzle-kit:
         specifier: 'catalog:'
         version: 1.0.0-rc.4
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3)
       effect:
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102
@@ -111,7 +117,7 @@ importers:
         version: 4.0.3(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.40)(@vue/server-renderer@3.5.40)(vue@3.5.40(typescript@6.0.3)))(esbuild@0.28.1)(magicast@0.5.3)(playwright-core@1.60.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.6)
       '@nuxt/ui':
         specifier: ^4.9.0
-        version: 4.9.0(93e902ee154b94ddee02df90a7a3f9ec)
+        version: 4.9.0(d62848af885d2702734bc3a56c647bfd)
       '@tanstack/table-core':
         specifier: ^8.21.3
         version: 8.21.3
@@ -120,22 +126,22 @@ importers:
         version: 13.9.0(vue@3.5.40(typescript@6.0.3))
       '@vueuse/nuxt':
         specifier: ^13.9.0
-        version: 13.9.0(magicast@0.5.3)(nuxt@4.5.0(9ed16452ae3a87615631e805d1fbe87b))(vue@3.5.40(typescript@6.0.3))
+        version: 13.9.0(magicast@0.5.3)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(vue@3.5.40(typescript@6.0.3))
       ai:
         specifier: ^7.0.48
         version: 7.0.48(zod@4.4.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3)
       evlog:
         specifier: ^2.22.0
-        version: 2.22.0(367266303dc43ca90057f28f6856a231)
+        version: 2.22.0(e8068d4b4d0cdefcb4c252f2af1431ef)
       exifr:
         specifier: ^7.1.3
         version: 7.1.3
       nuxt:
         specifier: 'catalog:'
-        version: 4.5.0(9ed16452ae3a87615631e805d1fbe87b)
+        version: 4.5.0(96c9a12831306dbf3c0a308051d7cbaf)
       nuxt-auth-utils:
         specifier: ^0.5.29
         version: 0.5.29(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -158,6 +164,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^5.20260712.1
         version: 5.20260712.1
+      '@distilled.cloud/nuxt':
+        specifier: ^0.17.1
+        version: 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@nuxt/eslint-plugin':
         specifier: 'catalog:'
         version: 1.15.2(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
@@ -202,7 +211,7 @@ importers:
         version: 2.5.8(magicast@0.5.3)
       '@nuxtjs/seo':
         specifier: ^5.3.4
-        version: 5.3.4(b3a3abfe90a30b8b9cd6d68917c7a7a0)
+        version: 5.3.4(87b9ed8355e6522c92ce1df18e680d37)
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
@@ -223,10 +232,10 @@ importers:
         version: 3.29.3
       nuxt-ai-ready:
         specifier: ^1.5.8
-        version: 1.5.8(d032f294098e20c70584a0bd6d18cf49)
+        version: 1.5.8(b9f7d4c3979c8e5f41449f7bce3fca6e)
       nuxt-skew-protection:
         specifier: ^1.3.1
-        version: 1.3.1(a9c3bd3d7387e6b31d0f19d8d8319b52)
+        version: 1.3.1(55401d4f02bce1a26b06f80352076643)
       reading-time:
         specifier: 2.0.0-1
         version: 2.0.0-1
@@ -243,6 +252,9 @@ importers:
         specifier: ^4.3.2
         version: 4.3.2
     devDependencies:
+      '@distilled.cloud/nuxt':
+        specifier: ^0.17.1
+        version: 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@iconify-json/akar-icons':
         specifier: ^1.2.7
         version: 1.2.7
@@ -257,13 +269,13 @@ importers:
         version: 1.15.2(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       '@nuxt/fonts':
         specifier: 0.14.0
-        version: 0.14.0(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(esbuild@0.28.1)(ioredis@5.10.1)(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 0.14.0(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(esbuild@0.28.1)(ioredis@5.10.1)(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@nuxt/icon':
         specifier: ^1.15.0
         version: 1.15.0(magicast@0.5.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@nuxt/image':
         specifier: 2.0.0-alpha.1
-        version: 2.0.0-alpha.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(magicast@0.5.3)
+        version: 2.0.0-alpha.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(magicast@0.5.3)
       '@nuxtjs/google-fonts':
         specifier: ^3.0.0
         version: 3.2.0(magicast@0.5.3)
@@ -290,13 +302,13 @@ importers:
         version: 13.9.0(vue@3.5.40(typescript@6.0.3))
       '@vueuse/nuxt':
         specifier: ^13.9.0
-        version: 13.9.0(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(vue@3.5.40(typescript@6.0.3))
+        version: 13.9.0(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(vue@3.5.40(typescript@6.0.3))
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.11.1
       nuxt:
         specifier: 'catalog:'
-        version: 4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3)
+        version: 4.5.0(133916b78b4d7caedebb9e59d45f96aa)
       nuxt-umami:
         specifier: ^3.2.1
         version: 3.2.1(magicast@0.5.3)
@@ -749,6 +761,9 @@ packages:
   '@cloudflare/workers-types@5.20260712.1':
     resolution: {integrity: sha512-tkQ18Lz41EPXLzh4cSuIGQzztDVueuGfTcjlP4M7Qa0rfHpVBNItf3GRkd9O0JgiXs9csAwz/kVv7sjYXSoF2w==}
 
+  '@cloudflare/workers-types@5.20260804.1':
+    resolution: {integrity: sha512-B1dwxpN6e5RZXZkE5zpZj+ooNeNZ1mwavLIyHDYe10ojhlGTwDfe8sAl7R1mMXc1cyIsbr+jKVdvmMEyVcdTdg==}
+
   '@colordx/core@5.4.3':
     resolution: {integrity: sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==}
 
@@ -776,20 +791,18 @@ packages:
     peerDependencies:
       devframe: 0.5.4
 
-  '@distilled.cloud/aws@0.30.3':
-    resolution: {integrity: sha512-6U/wO+fLNnqBlRnqFpF79edS5t6njDl/6UmnCVUfWpIQ4n23X0VY1ft0lzsaBa506xRtF4vRhMELR9FIp5DKUA==}
+  '@distilled.cloud/aws@1.0.0-rc.2':
+    resolution: {integrity: sha512-hTWmdpfaKt6yLQ1YrJ17tp0DXINH7Wm5WQ05ap1FZW13Kwv+HzejXc4QPOYS6KT00Tlrfm6EEkTd3fDrY8dSGQ==}
     peerDependencies:
       effect: 4.0.0-beta.102
 
-  '@distilled.cloud/axiom@0.30.3':
-    resolution: {integrity: sha512-U4YvXsvz/TDYfIbZNRVAv8Yx1mnbms/rBQ/RHnRQWhL0JzxZOZOQvToxkB4kh/oa8KT+QbjTkDxRJP/f6P0M1g==}
-    peerDependencies:
-      effect: 4.0.0-beta.102
+  '@distilled.cloud/axiom@1.0.0-rc.2':
+    resolution: {integrity: sha512-okRnWBdEQ6vYanYtiKbNzNJCgccEa7ZgeytHaNRTvIpHD4PlwG5WYwBsLkhTYjjudOvD5yjJ4H2N8dQQsJlGrg==}
 
-  '@distilled.cloud/cloudflare-rolldown-plugin@0.15.0':
-    resolution: {integrity: sha512-cBVl4Ck4Prf9/dPSvyQeGW+2CDLIKs+xbyUm/MgNOSyYDZYOLbsCnDePO4YwdvaxsT0oOZZIkSDDki2ve9DCHA==}
+  '@distilled.cloud/cloudflare-rolldown-plugin@0.16.0':
+    resolution: {integrity: sha512-O/F+fYtUrspoWq6D8hk37PPqPu+e2wu+F/p8QkhcJIgpaNxKJliPSgXl8WrEDSXOh5nGmnVTXFWu2YFnbEIcLg==}
     peerDependencies:
-      rolldown: ^1.1.5
+      rolldown: ~1.1.5
       vite: ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       rolldown:
@@ -797,10 +810,10 @@ packages:
       vite:
         optional: true
 
-  '@distilled.cloud/cloudflare-runtime@0.15.0':
-    resolution: {integrity: sha512-0xx+LCiBzNwmMPN1SnnD4GixVl8WZET3zaMPU51LYRU+VQQrxtetDjcjnI5q83UComjBmbS0c0Bp4j/7hgobyg==}
+  '@distilled.cloud/cloudflare-runtime@0.16.0':
+    resolution: {integrity: sha512-66vUbNlsl2uVjdOe3NlbU8qRICphMWRyTUj3hcchOyyrG3yR4OqWqNtEeztTpN/qb4kXasB52MqM1Sv7vqRHQg==}
     peerDependencies:
-      '@distilled.cloud/cloudflare': ^0.29.0
+      '@distilled.cloud/cloudflare': ^0.30.3
       '@effect/platform-bun': 4.0.0-beta.102
       '@effect/platform-node': 4.0.0-beta.102
       effect: 4.0.0-beta.102
@@ -810,11 +823,24 @@ packages:
       '@effect/platform-node':
         optional: true
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.15.0':
-    resolution: {integrity: sha512-+JYCTv/1Bqk3GRSb6e+UW61Pn2DFF68EAVvAbTYg5Z6tlztc2E7sd/pC4E2fsnAxtSMjwpFdrzlPqwQUq2HUQA==}
+  '@distilled.cloud/cloudflare-runtime@0.17.1':
+    resolution: {integrity: sha512-oNxg61oYm6h54JCaipjvHJpq858D9kXmDah31kbmkd1NhFbS7XWb+rF6M51vKWMHWHQKavvvS3rahE0/WmQPtw==}
     peerDependencies:
-      '@distilled.cloud/cloudflare': ^0.29.0
-      '@distilled.cloud/cloudflare-runtime': 0.15.0
+      '@distilled.cloud/cloudflare': ^0.30.3
+      '@effect/platform-bun': 4.0.0-beta.102
+      '@effect/platform-node': 4.0.0-beta.102
+      effect: 4.0.0-beta.102
+    peerDependenciesMeta:
+      '@effect/platform-bun':
+        optional: true
+      '@effect/platform-node':
+        optional: true
+
+  '@distilled.cloud/cloudflare-vite-plugin@0.16.0':
+    resolution: {integrity: sha512-JPg5m/XP0aDKzU5R0tDpJXPfZ19GiqW58Odg088mlDbXOOyVq9XCr9Zqee3QzANRJzBZXlldiMVpAbN1ZbxK1g==}
+    peerDependencies:
+      '@distilled.cloud/cloudflare': ^0.30.3
+      '@distilled.cloud/cloudflare-runtime': 0.16.0
       '@effect/platform-bun': 4.0.0-beta.102
       '@effect/platform-node': 4.0.0-beta.102
       effect: 4.0.0-beta.102
@@ -825,25 +851,37 @@ packages:
       '@effect/platform-node':
         optional: true
 
-  '@distilled.cloud/cloudflare@0.30.3':
-    resolution: {integrity: sha512-IwQyIZrfzRJ7Dn9Plsk5pMlr50CT72fMnD5YCFy31MKAthh906ewcO3NuJOKHGA8AF9u6SKTlebsQx4Jnj8uwA==}
+  '@distilled.cloud/cloudflare@1.0.0-rc.2':
+    resolution: {integrity: sha512-GGO5I8OxY/0iUT2bj+Ug+ivrjS6V1/nvdMRfL8dLOrpBkIhR8AFkLPgdatBwdIWeJWRE5wdU4wy+aeHJNp3oJA==}
+
+  '@distilled.cloud/core@1.0.0-rc.2':
+    resolution: {integrity: sha512-cVswTWsqC15Z9EPAOdRpfTG4UU8JPXhQEeH2ThW7Yh2BRl4lhIIOdxbRqUsRXPDMn24Mn08h2C3A6MGKP/KwLA==}
     peerDependencies:
       effect: 4.0.0-beta.102
 
-  '@distilled.cloud/core@0.30.3':
-    resolution: {integrity: sha512-RupX597cPmceEiOY6csihFbzH2WhDkfbwGCMk+Izx8+f16u+aLm4mgyrYoxj1/dzIHsyIfw8sFKgNPzAg0Rx2Q==}
+  '@distilled.cloud/framework-core@0.17.1':
+    resolution: {integrity: sha512-6NfV4YZBndU+cgpgrPhiQ9wlRPUjuoPFfNwgGGdNvtnR1y4iPDeW6tHZWI6DSL0ZvZLx+Z0MZB5uAQKEgmPuaw==}
     peerDependencies:
       effect: 4.0.0-beta.102
+      vite: ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
-  '@distilled.cloud/neon@0.30.3':
-    resolution: {integrity: sha512-4iW6lNvrJ/BuraKQ572bTQPNNtK/pFMqALoKjgozXR5jAZXbohRrD8/3QHLZW9cOAPenaHugwk4YIm0/+u4j5Q==}
-    peerDependencies:
-      effect: 4.0.0-beta.102
+  '@distilled.cloud/neon@1.0.0-rc.2':
+    resolution: {integrity: sha512-j1SRh/ionzWDeS8nO3+zF8h2zHNOddmTfqeev5LBs1pKeQWBJ3ZVDK3GeBACZzaeW3rCcll8eJEZ6fRnrp3xbw==}
 
-  '@distilled.cloud/planetscale@0.30.3':
-    resolution: {integrity: sha512-0ZcPqoXKl5uhJ6Ytw9UpgHa2t2pjwsuQFZn4OlnjZl0F/lToO/8TdXp4iKyw7Wog5tKTkfRYrQXVzRbaPKP3QQ==}
+  '@distilled.cloud/nuxt@0.17.1':
+    resolution: {integrity: sha512-eCKdihKIy/IrhlxhWHNgwbsyaxT4LUHaTHxBnzhixCVUfU6KlHaohMWYwmyLdFNQ524FsUsbiulNxqwJWRWdlg==}
     peerDependencies:
       effect: 4.0.0-beta.102
+      nuxt: '>=4.5.0'
+    peerDependenciesMeta:
+      nuxt:
+        optional: true
+
+  '@distilled.cloud/planetscale@1.0.0-rc.2':
+    resolution: {integrity: sha512-ucuQ0VM3bmovjzHoC/C7uo9634EQOJcI1gzx0jjdE2QIDsvy56UhjT3alilq9kADGz1V0/LUHOV3Xf1VqJf6Nw==}
 
   '@drizzle-team/brocli@0.12.0':
     resolution: {integrity: sha512-mlUE+rZ8CatQekLhnaiN91Iemdd+e2gFKooGlnRB3oPTL3VghLfX24dx7HrzMNeC1JrIB/0kpsfyty3f5HNfxQ==}
@@ -853,6 +891,11 @@ packages:
 
   '@dxup/unimport@0.1.2':
     resolution: {integrity: sha512-/B8YJGPzaYq1NbsQmwgP8EZqg40NpTw4ZB3suuI0TplbxKHeK94jeaawLmVhCv+YwUnOpiWEz9U6SeThku/8JQ==}
+
+  '@effect/platform-bun@4.0.0-beta.102':
+    resolution: {integrity: sha512-hTIb0jjTfXhNgnDq2OX5wrigc0OSvTT0VWWb1PLpMM395RJPu8rCIbTlGhy0NS7kZOd8FfgNi9e0sDhgyu+5Ag==}
+    peerDependencies:
+      effect: 4.0.0-beta.102
 
   '@effect/platform-node-shared@4.0.0-beta.102':
     resolution: {integrity: sha512-gVd793I72MrkX4dXo7eYtRKfNj0RW4eMRfVEKEJI16h2+mBDCzQ+gqMrog2hSTHQnaIbvbYShNQ4TVGuRCYZeQ==}
@@ -872,8 +915,18 @@ packages:
     peerDependencies:
       effect: 4.0.0-beta.102
 
+  '@effect/sql-mysql2@4.0.0-beta.102':
+    resolution: {integrity: sha512-dLt7NG0pBHvWvEvwjACEdZfLt32VHg7wZU2qOsS8HiYZcm+NZrv2Bkdqm+GRwWqcGxV1Q125wld8seXC+YN7CQ==}
+    peerDependencies:
+      effect: 4.0.0-beta.102
+
   '@effect/sql-pg@4.0.0-beta.102':
     resolution: {integrity: sha512-02a+fNfECWCZIZcgHl7OLQN2jZj42gq90EdwdnvR3KA6GLGypY02swABS4zFtaW9H80rTa0ukqVnTdcO/DT5GQ==}
+    peerDependencies:
+      effect: 4.0.0-beta.102
+
+  '@effect/sql-sqlite-do@4.0.0-beta.104':
+    resolution: {integrity: sha512-g/pX4wpVzr6ScmROXHjlyqm2HCgx0TkOD7xuOFk0MG1/crh7tuUx+AcLUbI0LNY+whfqE+uRam2R7gfNXp1Qpw==}
     peerDependencies:
       effect: 4.0.0-beta.102
 
@@ -3037,6 +3090,11 @@ packages:
   '@prisma/query-plan-executor@7.2.0':
     resolution: {integrity: sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==}
 
+  '@puppeteer/browsers@2.13.2':
+    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
@@ -3953,6 +4011,9 @@ packages:
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -4108,6 +4169,9 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/project-service@8.59.3':
     resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
@@ -4511,17 +4575,22 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
-  alchemy@2.0.0-beta.67:
-    resolution: {integrity: sha512-kFEKEXtRdf781lRzGyYinPRVgrMKJFs5MNQTxF2Y5RIxyA2qCsK0NOOBBoOzYmGOln8e3CIYF/oEASFQjffXJA==}
+  alchemy@2.0.0-beta.68:
+    resolution: {integrity: sha512-jD2bS3K6HZaqi5WhF0amcn8xYrY/9X3bgIxRhXdHvOWkS0aoCYg2K8wzgze6Oqlr0WzyFVl/OobuTS9jvwfDJg==}
     hasBin: true
     peerDependencies:
       '@aws/durable-execution-sdk-js': ^2.1.0
       '@effect/platform-bun': 4.0.0-beta.102
       '@effect/platform-node': 4.0.0-beta.102
+      '@effect/sql-mysql2': '>=4.0.0-beta.102 || >=4.0.0'
       '@effect/sql-pg': 4.0.0-beta.102
+      '@vercel/nft': ^1.10.2
       drizzle-kit: 1.0.0-rc.4
       drizzle-orm: 1.0.0-rc.4
       effect: 4.0.0-beta.102
+      mongodb: ^6.10.0
+      mysql2: ^3.15.3
+      pg: ^8.13.0
       vite: ^8.0.7
       ws: ^8.20.0
     peerDependenciesMeta:
@@ -4531,11 +4600,21 @@ packages:
         optional: true
       '@effect/platform-node':
         optional: true
+      '@effect/sql-mysql2':
+        optional: true
       '@effect/sql-pg':
+        optional: true
+      '@vercel/nft':
         optional: true
       drizzle-kit:
         optional: true
       drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
         optional: true
       vite:
         optional: true
@@ -4599,6 +4678,10 @@ packages:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
@@ -4638,6 +4721,14 @@ packages:
       react-native-b4a:
         optional: true
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -4653,6 +4744,35 @@ packages:
       bare-abort-controller:
         optional: true
 
+  bare-fs@4.8.0:
+    resolution: {integrity: sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==}
+    engines: {bare: '>=1.28.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.7:
+    resolution: {integrity: sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==}
+
   base64-js@0.0.8:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
     engines: {node: '>= 0.4'}
@@ -4664,6 +4784,10 @@ packages:
     resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -4716,6 +4840,9 @@ packages:
   bson@6.10.4:
     resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
     engines: {node: '>=16.20.1'}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
@@ -4818,6 +4945,10 @@ packages:
   cli-truncate@5.2.0:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
@@ -5186,6 +5317,10 @@ packages:
   dagre-d3-es@7.0.11:
     resolution: {integrity: sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw==}
 
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   dayjs@1.11.18:
     resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
 
@@ -5258,6 +5393,10 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
 
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
@@ -5744,6 +5883,11 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -5769,6 +5913,11 @@ packages:
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -5889,6 +6038,11 @@ packages:
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fake-indexeddb@6.2.5:
     resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
     engines: {node: '>=18'}
@@ -5944,6 +6098,9 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6080,12 +6237,20 @@ packages:
   get-port-please@3.2.0:
     resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   giget@3.3.0:
     resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
@@ -6201,6 +6366,10 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   http-shutdown@1.2.2:
     resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -6300,6 +6469,10 @@ packages:
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
     engines: {node: '>=12.22.0'}
+
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
+    engines: {node: '>= 12'}
 
   ipx@3.1.1:
     resolution: {integrity: sha512-7Xnt54Dco7uYkfdAw0r2vCly3z0rSaVhEXMzPvl3FndsTVm5p26j+PO+gyinkYmcsEUvX2Rh7OGK7KzYWRu6BA==}
@@ -6685,6 +6858,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
@@ -6924,6 +7101,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
 
   nitropack@2.13.4:
     resolution: {integrity: sha512-tX7bT6zxNeMwkc6hxHiZeUoTOjVrcjoh1Z3cmxOlodIqjl4HISgqfGOmkWSayky3Nv9Z5+KQH52F8nmXJY5AAA==}
@@ -7300,6 +7481,14 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -7364,6 +7553,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -7709,6 +7901,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
@@ -7756,6 +7952,13 @@ packages:
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -7850,6 +8053,10 @@ packages:
 
   request-ip@3.3.0:
     resolution: {integrity: sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -8086,8 +8293,20 @@ packages:
     resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
     engines: {node: '>=8.0.0'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   smob@1.5.0:
     resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8150,6 +8369,9 @@ packages:
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -8263,6 +8485,9 @@ packages:
   tar-fs@2.1.5:
     resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
 
+  tar-fs@3.1.3:
+    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
@@ -8274,6 +8499,9 @@ packages:
     resolution: {integrity: sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==}
     engines: {node: '>=18'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   terminal-size@4.0.1:
     resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
@@ -9039,13 +9267,24 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yjs@13.6.31:
     resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
@@ -9635,6 +9874,8 @@ snapshots:
 
   '@cloudflare/workers-types@5.20260712.1': {}
 
+  '@cloudflare/workers-types@5.20260804.1': {}
+
   '@colordx/core@5.4.3': {}
 
   '@comark/vue@0.5.1(vue@3.5.40(typescript@6.0.3))':
@@ -9665,13 +9906,13 @@ snapshots:
       - vite
       - webpack
 
-  '@distilled.cloud/aws@0.30.3(effect@4.0.0-beta.102)':
+  '@distilled.cloud/aws@1.0.0-rc.2(effect@4.0.0-beta.102)':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1081.0
       '@aws-sdk/types': 3.974.0
-      '@distilled.cloud/core': 0.30.3(effect@4.0.0-beta.102)
+      '@distilled.cloud/core': 1.0.0-rc.2(effect@4.0.0-beta.102)
       '@smithy/shared-ini-file-loader': 4.6.8
       '@smithy/types': 4.16.1
       '@smithy/util-base64': 4.5.8
@@ -9679,12 +9920,16 @@ snapshots:
       effect: 4.0.0-beta.102
       fast-xml-parser: 5.10.1
 
-  '@distilled.cloud/axiom@0.30.3(effect@4.0.0-beta.102)':
+  '@distilled.cloud/axiom@1.0.0-rc.2':
     dependencies:
-      '@distilled.cloud/core': 0.30.3(effect@4.0.0-beta.102)
+      '@distilled.cloud/core': 1.0.0-rc.2(effect@4.0.0-beta.102)
+      '@effect/platform-bun': 4.0.0-beta.102(effect@4.0.0-beta.102)
       effect: 4.0.0-beta.102
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
-  '@distilled.cloud/cloudflare-rolldown-plugin@0.15.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)':
+  '@distilled.cloud/cloudflare-rolldown-plugin@0.16.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)
       magic-string: 0.30.21
@@ -9695,46 +9940,126 @@ snapshots:
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.15.0(@distilled.cloud/cloudflare@0.30.3(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)':
+  '@distilled.cloud/cloudflare-runtime@0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
-      '@distilled.cloud/cloudflare': 0.30.3(effect@4.0.0-beta.102)
+      '@distilled.cloud/cloudflare': 1.0.0-rc.2
+      '@puppeteer/browsers': 2.13.2
       effect: 4.0.0-beta.102
+      sharp: 0.34.5
       workerd: 1.20260704.1
     optionalDependencies:
+      '@effect/platform-bun': 4.0.0-beta.102(effect@4.0.0-beta.102)
       '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1)
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.15.0(@distilled.cloud/cloudflare-runtime@0.15.0(@distilled.cloud/cloudflare@0.30.3(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102))(@distilled.cloud/cloudflare@0.30.3(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)':
+  '@distilled.cloud/cloudflare-runtime@0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)':
     dependencies:
-      '@distilled.cloud/cloudflare': 0.30.3(effect@4.0.0-beta.102)
-      '@distilled.cloud/cloudflare-rolldown-plugin': 0.15.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)
-      '@distilled.cloud/cloudflare-runtime': 0.15.0(@distilled.cloud/cloudflare@0.30.3(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
+      '@alchemy.run/node-utils': 0.0.5
+      '@distilled.cloud/cloudflare': 1.0.0-rc.2
+      '@puppeteer/browsers': 2.13.2
+      effect: 4.0.0-beta.102
+      sharp: 0.34.5
+      workerd: 1.20260704.1
+    optionalDependencies:
+      '@effect/platform-bun': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1)
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
+  '@distilled.cloud/cloudflare-vite-plugin@0.16.0(@distilled.cloud/cloudflare-runtime@0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102))(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)':
+    dependencies:
+      '@distilled.cloud/cloudflare': 1.0.0-rc.2
+      '@distilled.cloud/cloudflare-rolldown-plugin': 0.16.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)
+      '@distilled.cloud/cloudflare-runtime': 0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
       effect: 4.0.0-beta.102
       vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
     optionalDependencies:
+      '@effect/platform-bun': 4.0.0-beta.102(effect@4.0.0-beta.102)
       '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1)
     transitivePeerDependencies:
       - rolldown
       - workerd
 
-  '@distilled.cloud/cloudflare@0.30.3(effect@4.0.0-beta.102)':
+  '@distilled.cloud/cloudflare@1.0.0-rc.2':
     dependencies:
-      '@distilled.cloud/core': 0.30.3(effect@4.0.0-beta.102)
+      '@distilled.cloud/core': 1.0.0-rc.2(effect@4.0.0-beta.102)
+      '@effect/platform-bun': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      effect: 4.0.0-beta.102
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@distilled.cloud/core@1.0.0-rc.2(effect@4.0.0-beta.102)':
+    dependencies:
       effect: 4.0.0-beta.102
 
-  '@distilled.cloud/core@0.30.3(effect@4.0.0-beta.102)':
+  '@distilled.cloud/framework-core@0.17.1(effect@4.0.0-beta.102)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       effect: 4.0.0-beta.102
+    optionalDependencies:
+      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
 
-  '@distilled.cloud/neon@0.30.3(effect@4.0.0-beta.102)':
+  '@distilled.cloud/neon@1.0.0-rc.2':
     dependencies:
-      '@distilled.cloud/core': 0.30.3(effect@4.0.0-beta.102)
+      '@distilled.cloud/core': 1.0.0-rc.2(effect@4.0.0-beta.102)
+      '@effect/platform-bun': 4.0.0-beta.102(effect@4.0.0-beta.102)
       effect: 4.0.0-beta.102
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
-  '@distilled.cloud/planetscale@0.30.3(effect@4.0.0-beta.102)':
+  '@distilled.cloud/nuxt@0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
-      '@distilled.cloud/core': 0.30.3(effect@4.0.0-beta.102)
+      '@distilled.cloud/cloudflare-runtime': 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
+      '@distilled.cloud/framework-core': 0.17.1(effect@4.0.0-beta.102)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       effect: 4.0.0-beta.102
+      fast-glob: 3.3.3
+    optionalDependencies:
+      nuxt: 4.5.0(133916b78b4d7caedebb9e59d45f96aa)
+    transitivePeerDependencies:
+      - '@distilled.cloud/cloudflare'
+      - '@effect/platform-bun'
+      - '@effect/platform-node'
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+      - vite
+
+  '@distilled.cloud/nuxt@0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@distilled.cloud/cloudflare-runtime': 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
+      '@distilled.cloud/framework-core': 0.17.1(effect@4.0.0-beta.102)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      effect: 4.0.0-beta.102
+      fast-glob: 3.3.3
+    optionalDependencies:
+      nuxt: 4.5.0(96c9a12831306dbf3c0a308051d7cbaf)
+    transitivePeerDependencies:
+      - '@distilled.cloud/cloudflare'
+      - '@effect/platform-bun'
+      - '@effect/platform-node'
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+      - vite
+
+  '@distilled.cloud/planetscale@1.0.0-rc.2':
+    dependencies:
+      '@distilled.cloud/core': 1.0.0-rc.2(effect@4.0.0-beta.102)
+      '@effect/platform-bun': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      effect: 4.0.0-beta.102
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@drizzle-team/brocli@0.12.0': {}
 
@@ -9764,6 +10089,14 @@ snapshots:
 
   '@dxup/unimport@0.1.2': {}
 
+  '@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102)':
+    dependencies:
+      '@effect/platform-node-shared': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      effect: 4.0.0-beta.102
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@effect/platform-node-shared@4.0.0-beta.102(effect@4.0.0-beta.102)':
     dependencies:
       '@types/ws': 8.18.1
@@ -9786,8 +10119,15 @@ snapshots:
 
   '@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102)':
     dependencies:
-      '@cloudflare/workers-types': 5.20260712.1
+      '@cloudflare/workers-types': 5.20260804.1
       effect: 4.0.0-beta.102
+
+  '@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102)':
+    dependencies:
+      effect: 4.0.0-beta.102
+      mysql2: 3.22.6(@types/node@22.18.10)
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102)':
     dependencies:
@@ -9799,6 +10139,10 @@ snapshots:
       pg-types: 4.1.0
     transitivePeerDependencies:
       - pg-native
+
+  '@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102)':
+    dependencies:
+      effect: 4.0.0-beta.102
 
   '@effect/vitest@4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.6)':
     dependencies:
@@ -10618,6 +10962,7 @@ snapshots:
   '@mongodb-js/saslprep@1.4.13':
     dependencies:
       sparse-bitfield: 3.0.3
+    optional: true
 
   '@mrleebo/prisma-ast@0.13.1':
     dependencies:
@@ -10895,13 +11240,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/fonts@0.14.0(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(esbuild@0.28.1)(ioredis@5.10.1)(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@nuxt/fonts@0.14.0(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(esbuild@0.28.1)(ioredis@5.10.1)(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/devtools-kit': 3.2.4(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       consola: 3.4.2
       defu: 6.1.7
-      fontless: 0.2.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      fontless: 0.2.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       h3: 1.15.11
       magic-regexp: 0.10.0
       ofetch: 1.5.1
@@ -10911,7 +11256,7 @@ snapshots:
       ufo: 1.6.4
       unifont: 0.7.4
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -10945,13 +11290,13 @@ snapshots:
       - vite
       - webpack
 
-  '@nuxt/fonts@0.14.0(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(esbuild@0.28.1)(ioredis@5.10.1)(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@nuxt/fonts@0.14.0(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(esbuild@0.28.1)(ioredis@5.10.1)(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/devtools-kit': 3.2.4(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       consola: 3.4.2
       defu: 6.1.7
-      fontless: 0.2.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      fontless: 0.2.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       h3: 1.15.11
       magic-regexp: 0.10.0
       ofetch: 1.5.1
@@ -10961,7 +11306,7 @@ snapshots:
       ufo: 1.6.4
       unifont: 0.7.4
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11042,7 +11387,7 @@ snapshots:
       - vite
       - vue
 
-  '@nuxt/image@2.0.0-alpha.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(magicast@0.5.3)':
+  '@nuxt/image@2.0.0-alpha.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(magicast@0.5.3)':
     dependencies:
       '@nuxt/kit': 3.21.5(magicast@0.5.3)
       consola: 3.4.2
@@ -11055,7 +11400,7 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.6.4
     optionalDependencies:
-      ipx: 3.1.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      ipx: 3.1.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11194,7 +11539,7 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/nitro-server@4.5.0(6c8e8883c3d2dc98a87d147c44e64209)':
+  '@nuxt/nitro-server@4.5.0(4335eb9b62c8a43a2adb44176f3a9146)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -11211,9 +11556,9 @@ snapshots:
       impound: 1.1.5(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       nostics: 1.2.0
-      nuxt: 4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3)
+      nuxt: 4.5.0(133916b78b4d7caedebb9e59d45f96aa)
       nypm: 0.6.8
       ohash: 2.0.11
       pathe: 2.0.3
@@ -11221,7 +11566,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
       vue: 3.5.40(typescript@6.0.3)
       vue-bundle-renderer: 2.3.1
       vue-devtools-stub: 0.1.0
@@ -11279,7 +11624,7 @@ snapshots:
       - webpack
       - xml2js
 
-  '@nuxt/nitro-server@4.5.0(964fa8acb3122f68500aa64db34fcc55)':
+  '@nuxt/nitro-server@4.5.0(9deaf1e2abe9e09c056b7228dbd5cc41)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -11296,9 +11641,9 @@ snapshots:
       impound: 1.1.5(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       nostics: 1.2.0
-      nuxt: 4.5.0(9ed16452ae3a87615631e805d1fbe87b)
+      nuxt: 4.5.0(96c9a12831306dbf3c0a308051d7cbaf)
       nypm: 0.6.8
       ohash: 2.0.11
       pathe: 2.0.3
@@ -11306,7 +11651,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
       vue: 3.5.40(typescript@6.0.3)
       vue-bundle-renderer: 2.3.1
       vue-devtools-stub: 0.1.0
@@ -11364,7 +11709,7 @@ snapshots:
       - webpack
       - xml2js
 
-  '@nuxt/nitro-server@4.5.0(e1f2260672125d782067ee19ea61f533)':
+  '@nuxt/nitro-server@4.5.0(e01bd71ada403ae072a54d3bc61413fc)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -11381,9 +11726,9 @@ snapshots:
       impound: 1.1.5(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       nostics: 1.2.0
-      nuxt: 4.5.0(9e2c98569c50f8e722d2aef5b4a88ea0)
+      nuxt: 4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe)
       nypm: 0.6.8
       ohash: 2.0.11
       pathe: 2.0.3
@@ -11391,7 +11736,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
       vue: 3.5.40(typescript@6.0.3)
       vue-bundle-renderer: 2.3.1
       vue-devtools-stub: 0.1.0
@@ -11525,11 +11870,11 @@ snapshots:
       - vite
       - webpack
 
-  '@nuxt/ui@4.9.0(93e902ee154b94ddee02df90a7a3f9ec)':
+  '@nuxt/ui@4.9.0(d62848af885d2702734bc3a56c647bfd)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@iconify/vue': 5.0.1(vue@3.5.40(typescript@6.0.3))
-      '@nuxt/fonts': 0.14.0(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(esbuild@0.28.1)(ioredis@5.10.1)(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@nuxt/fonts': 0.14.0(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(esbuild@0.28.1)(ioredis@5.10.1)(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@nuxt/icon': 2.3.1(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@nuxt/schema': 4.5.0
@@ -11645,69 +11990,7 @@ snapshots:
       - vue
       - webpack
 
-  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(9e2c98569c50f8e722d2aef5b4a88ea0))(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
-    dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.6(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-      autoprefixer: 10.5.4(postcss@8.5.20)
-      consola: 3.4.2
-      cssnano: 8.0.2(postcss@8.5.20)
-      defu: 6.1.7
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.0
-      get-port-please: 3.2.0
-      jiti: 2.7.0
-      js-tokens: 10.0.0
-      knitwork: 1.3.0
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      nuxt: 4.5.0(9e2c98569c50f8e722d2aef5b4a88ea0)
-      nypm: 0.6.8
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      postcss: 8.5.20
-      rolldown-string: 0.3.1(rolldown@1.2.0)
-      seroval: 1.5.6
-      std-env: 4.2.0
-      ufo: 1.6.4
-      unenv: 2.0.0-rc.24
-      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
-      vite-node: 6.0.0(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
-      vite-plugin-checker: 0.14.4(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.2.9(typescript@6.0.3))
-      vue: 3.5.40(typescript@6.0.3)
-      vue-bundle-renderer: 2.3.1
-    optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      rolldown: 1.2.0
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.4)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - eslint
-      - less
-      - magic-string
-      - magicast
-      - meow
-      - optionator
-      - oxc-parser
-      - oxlint
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - unplugin
-      - vue-tsc
-      - yaml
-
-  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(9ed16452ae3a87615631e805d1fbe87b))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
@@ -11724,7 +12007,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.0(9ed16452ae3a87615631e805d1fbe87b)
+      nuxt: 4.5.0(133916b78b4d7caedebb9e59d45f96aa)
       nypm: 0.6.8
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -11769,7 +12052,69 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe))(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
+    dependencies:
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.6(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      autoprefixer: 10.5.4(postcss@8.5.20)
+      consola: 3.4.2
+      cssnano: 8.0.2(postcss@8.5.20)
+      defu: 6.1.7
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.0
+      get-port-please: 3.2.0
+      jiti: 2.7.0
+      js-tokens: 10.0.0
+      knitwork: 1.3.0
+      mlly: 1.8.2
+      mocked-exports: 0.1.1
+      nuxt: 4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe)
+      nypm: 0.6.8
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      postcss: 8.5.20
+      rolldown-string: 0.3.1(rolldown@1.2.0)
+      seroval: 1.5.6
+      std-env: 4.2.0
+      ufo: 1.6.4
+      unenv: 2.0.0-rc.24
+      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite-node: 6.0.0(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite-plugin-checker: 0.14.4(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.2.9(typescript@6.0.3))
+      vue: 3.5.40(typescript@6.0.3)
+      vue-bundle-renderer: 2.3.1
+    optionalDependencies:
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      rolldown: 1.2.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.4)
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - eslint
+      - less
+      - magic-string
+      - magicast
+      - meow
+      - optionator
+      - oxc-parser
+      - oxlint
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - unplugin
+      - vue-tsc
+      - yaml
+
+  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
@@ -11786,7 +12131,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3)
+      nuxt: 4.5.0(96c9a12831306dbf3c0a308051d7cbaf)
       nypm: 0.6.8
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -11864,15 +12209,15 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxtjs/robots@6.1.3(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)':
+  '@nuxtjs/robots@6.1.3(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -11889,18 +12234,18 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/seo@5.3.4(b3a3abfe90a30b8b9cd6d68917c7a7a0)':
+  '@nuxtjs/seo@5.3.4(87b9ed8355e6522c92ce1df18e680d37)':
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@nuxtjs/robots': 6.1.3(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      '@nuxtjs/sitemap': 8.3.0(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxt: 4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3)
-      nuxt-link-checker: 5.1.3(@nuxt/schema@4.5.0)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxt-og-image: 6.7.4(f3015b2e0de74325fb46c9afe8020464)
-      nuxt-schema-org: 6.2.7(@nuxt/schema@4.5.0)(@unhead/vue@3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unhead@3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxt-seo-utils: 8.3.2(@nuxt/schema@4.5.0)(@types/node@22.18.10)(@unhead/vue@3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(esbuild@0.28.1)(lightningcss@1.32.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(unhead@3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      '@nuxtjs/robots': 6.1.3(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      '@nuxtjs/sitemap': 8.3.0(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt: 4.5.0(133916b78b4d7caedebb9e59d45f96aa)
+      nuxt-link-checker: 5.1.3(@nuxt/schema@4.5.0)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-og-image: 6.7.4(a1399fcc221e84acb41f4dc9be5ed6ce)
+      nuxt-schema-org: 6.2.7(@nuxt/schema@4.5.0)(@unhead/vue@3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unhead@3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-seo-utils: 8.3.2(@nuxt/schema@4.5.0)(@types/node@22.18.10)(@unhead/vue@3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(esbuild@0.28.1)(lightningcss@1.32.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(unhead@3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11961,14 +12306,14 @@ snapshots:
       - webpack
       - zod
 
-  '@nuxtjs/sitemap@8.3.0(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)':
+  '@nuxtjs/sitemap@8.3.0(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       consola: 3.4.2
       defu: 6.1.7
       fast-xml-parser: 5.10.1
-      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -12448,6 +12793,21 @@ snapshots:
       '@prisma/debug': 7.2.0
 
   '@prisma/query-plan-executor@7.2.0': {}
+
+  '@puppeteer/browsers@2.13.2':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.8.5
+      tar-fs: 3.1.3
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -13160,6 +13520,8 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.31)
       yjs: 13.6.31
 
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -13322,15 +13684,22 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@types/webidl-conversions@7.0.3': {}
+  '@types/webidl-conversions@7.0.3':
+    optional: true
 
   '@types/whatwg-url@11.0.5':
     dependencies:
       '@types/webidl-conversions': 7.0.3
+    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.18.10
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.18.10
+    optional: true
 
   '@typescript-eslint/project-service@8.59.3(typescript@6.0.3)':
     dependencies:
@@ -13479,6 +13848,7 @@ snapshots:
       - encoding
       - rollup
       - supports-color
+    optional: true
 
   '@vercel/nft@1.5.0(rollup@4.60.4)':
     dependencies:
@@ -13834,24 +14204,24 @@ snapshots:
 
   '@vueuse/metadata@14.3.0': {}
 
-  '@vueuse/nuxt@13.9.0(magicast@0.5.3)(nuxt@4.5.0(9ed16452ae3a87615631e805d1fbe87b))(vue@3.5.40(typescript@6.0.3))':
+  '@vueuse/nuxt@13.9.0(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       '@nuxt/kit': 3.21.5(magicast@0.5.3)
       '@vueuse/core': 13.9.0(vue@3.5.40(typescript@6.0.3))
       '@vueuse/metadata': 13.9.0
       local-pkg: 1.2.1
-      nuxt: 4.5.0(9ed16452ae3a87615631e805d1fbe87b)
+      nuxt: 4.5.0(133916b78b4d7caedebb9e59d45f96aa)
       vue: 3.5.40(typescript@6.0.3)
     transitivePeerDependencies:
       - magicast
 
-  '@vueuse/nuxt@13.9.0(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(vue@3.5.40(typescript@6.0.3))':
+  '@vueuse/nuxt@13.9.0(magicast@0.5.3)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       '@nuxt/kit': 3.21.5(magicast@0.5.3)
       '@vueuse/core': 13.9.0(vue@3.5.40(typescript@6.0.3))
       '@vueuse/metadata': 13.9.0
       local-pkg: 1.2.1
-      nuxt: 4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3)
+      nuxt: 4.5.0(96c9a12831306dbf3c0a308051d7cbaf)
       vue: 3.5.40(typescript@6.0.3)
     transitivePeerDependencies:
       - magicast
@@ -13907,21 +14277,22 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  alchemy@2.0.0-beta.67(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@types/node@22.18.10)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(effect@4.0.0-beta.102)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.6)(workerd@1.20260708.1)(ws@8.21.0):
+  alchemy@2.0.0-beta.68(74327ec9d35598bd395fb5ad2aa58efd):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1081.0
       '@clack/prompts': 1.7.0
-      '@distilled.cloud/aws': 0.30.3(effect@4.0.0-beta.102)
-      '@distilled.cloud/axiom': 0.30.3(effect@4.0.0-beta.102)
-      '@distilled.cloud/cloudflare': 0.30.3(effect@4.0.0-beta.102)
-      '@distilled.cloud/cloudflare-rolldown-plugin': 0.15.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)
-      '@distilled.cloud/cloudflare-runtime': 0.15.0(@distilled.cloud/cloudflare@0.30.3(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
-      '@distilled.cloud/cloudflare-vite-plugin': 0.15.0(@distilled.cloud/cloudflare-runtime@0.15.0(@distilled.cloud/cloudflare@0.30.3(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102))(@distilled.cloud/cloudflare@0.30.3(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)
-      '@distilled.cloud/core': 0.30.3(effect@4.0.0-beta.102)
-      '@distilled.cloud/neon': 0.30.3(effect@4.0.0-beta.102)
-      '@distilled.cloud/planetscale': 0.30.3(effect@4.0.0-beta.102)
+      '@distilled.cloud/aws': 1.0.0-rc.2(effect@4.0.0-beta.102)
+      '@distilled.cloud/axiom': 1.0.0-rc.2
+      '@distilled.cloud/cloudflare': 1.0.0-rc.2
+      '@distilled.cloud/cloudflare-rolldown-plugin': 0.16.0(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)
+      '@distilled.cloud/cloudflare-runtime': 0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
+      '@distilled.cloud/cloudflare-vite-plugin': 0.16.0(@distilled.cloud/cloudflare-runtime@0.16.0(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102))(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(rolldown@1.1.5)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(workerd@1.20260708.1)
+      '@distilled.cloud/core': 1.0.0-rc.2(effect@4.0.0-beta.102)
+      '@distilled.cloud/neon': 1.0.0-rc.2
+      '@distilled.cloud/planetscale': 1.0.0-rc.2
       '@effect/sql-d1': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      '@effect/sql-sqlite-do': 4.0.0-beta.104(effect@4.0.0-beta.102)
       '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.6)
       '@libsql/client': 0.17.4
       '@octokit/rest': 22.0.1
@@ -13931,7 +14302,6 @@ snapshots:
       '@smithy/shared-ini-file-loader': 4.6.8
       '@smithy/types': 4.16.1
       '@types/aws-lambda': 8.10.162
-      '@vercel/nft': 1.10.2(rollup@4.60.4)
       aws4fetch: 1.0.20
       capnweb: 0.6.1
       effect: 4.0.0-beta.102
@@ -13940,36 +14310,32 @@ snapshots:
       ink: 6.8.0(react@19.2.7)
       jszip: 3.10.1
       libsodium-wrappers: 0.8.4
-      mongodb: 6.21.0(@aws-sdk/credential-providers@3.1081.0)
-      mysql2: 3.22.6(@types/node@22.18.10)
       pathe: 2.0.3
-      pg: 8.22.0
       picomatch: 4.0.5
       react: 19.2.7
       rolldown: 1.1.5
       undici: 7.28.0
       yaml: 2.9.0
     optionalDependencies:
+      '@effect/platform-bun': 4.0.0-beta.102(effect@4.0.0-beta.102)
       '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1)
+      '@effect/sql-mysql2': 4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102)
       '@effect/sql-pg': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      '@vercel/nft': 1.10.2(rollup@4.60.4)
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3)
+      mongodb: 6.21.0(@aws-sdk/credential-providers@3.1081.0)(socks@2.8.9)
+      mysql2: 3.22.6(@types/node@22.18.10)
+      pg: 8.22.0
       vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
       ws: 8.21.0
     transitivePeerDependencies:
-      - '@mongodb-js/zstd'
-      - '@types/node'
       - '@types/react'
+      - bare-abort-controller
+      - bare-buffer
       - bufferutil
-      - encoding
-      - gcp-metadata
-      - kerberos
-      - mongodb-client-encryption
-      - pg-native
       - react-devtools-core
-      - rollup
-      - snappy
-      - socks
+      - react-native-b4a
       - supports-color
       - typescript
       - utf-8-validate
@@ -14037,6 +14403,10 @@ snapshots:
       '@babel/parser': 7.29.7
       pathe: 2.0.3
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
   ast-v8-to-istanbul@1.0.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -14070,17 +14440,53 @@ snapshots:
 
   b4a@1.7.3: {}
 
+  b4a@1.8.1:
+    optional: true
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
   bare-events@2.8.0: {}
 
+  bare-fs@4.8.0:
+    dependencies:
+      bare-events: 2.8.0
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.8.0)
+      bare-url: 2.4.7
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  bare-path@3.1.1:
+    optional: true
+
+  bare-stream@2.13.3(bare-events@2.8.0):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
+    optional: true
+
+  bare-url@2.4.7:
+    dependencies:
+      bare-path: 3.1.1
+    optional: true
+
   base64-js@0.0.8: {}
 
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.43: {}
+
+  basic-ftp@5.3.1: {}
 
   before-after-hook@4.0.0: {}
 
@@ -14134,7 +14540,10 @@ snapshots:
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
-  bson@6.10.4: {}
+  bson@6.10.4:
+    optional: true
+
+  buffer-crc32@0.2.13: {}
 
   buffer-crc32@1.0.0: {}
 
@@ -14249,6 +14658,12 @@ snapshots:
     dependencies:
       slice-ansi: 8.0.0
       string-width: 8.2.2
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   cliui@9.0.1:
     dependencies:
@@ -14636,22 +15051,32 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.17.21
 
+  data-uri-to-buffer@6.0.2: {}
+
   dayjs@1.11.18: {}
 
-  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)):
+  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
       better-sqlite3: 12.11.1
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)
       mysql2: 3.22.6(@types/node@22.18.10)
 
-  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)):
+  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
       better-sqlite3: 13.0.1
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3)
+      mysql2: 3.22.6(@types/node@22.18.10)
+
+  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.3.15
+      '@libsql/client': 0.17.4
+      better-sqlite3: 13.0.1
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3)
       mysql2: 3.22.6(@types/node@22.18.10)
 
   debug@2.6.9:
@@ -14682,6 +15107,12 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.7: {}
+
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
 
   delaunator@5.0.1:
     dependencies:
@@ -14787,9 +15218,9 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0):
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260712.1
+      '@cloudflare/workers-types': 5.20260804.1
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
       '@upstash/redis': 1.35.5
@@ -14797,11 +15228,30 @@ snapshots:
       mysql2: 3.22.6(@types/node@22.18.10)
       pg: 8.22.0
 
-  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3):
     optionalDependencies:
       '@cloudflare/workers-types': 5.20260712.1
       '@effect/sql-d1': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      '@effect/sql-mysql2': 4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102)
       '@effect/sql-pg': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      '@effect/sql-sqlite-do': 4.0.0-beta.104(effect@4.0.0-beta.102)
+      '@electric-sql/pglite': 0.3.15
+      '@libsql/client': 0.17.4
+      '@upstash/redis': 1.35.5
+      better-sqlite3: 13.0.1
+      effect: 4.0.0-beta.102
+      mysql2: 3.22.6(@types/node@22.18.10)
+      pg: 8.22.0
+      valibot: 1.4.2(typescript@6.0.3)
+      zod: 4.4.3
+
+  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3):
+    optionalDependencies:
+      '@cloudflare/workers-types': 5.20260804.1
+      '@effect/sql-d1': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      '@effect/sql-mysql2': 4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102)
+      '@effect/sql-pg': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      '@effect/sql-sqlite-do': 4.0.0-beta.104(effect@4.0.0-beta.102)
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
       '@upstash/redis': 1.35.5
@@ -15011,6 +15461,14 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -15065,6 +15523,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -15097,13 +15557,13 @@ snapshots:
 
   eventsource-parser@3.1.0: {}
 
-  evlog@2.22.0(367266303dc43ca90057f28f6856a231):
+  evlog@2.22.0(e8068d4b4d0cdefcb4c252f2af1431ef):
     optionalDependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       ai: 7.0.48(zod@4.4.3)
       h3: 1.15.11
       hono: 4.11.4
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       ofetch: 1.5.1
       react: 19.2.7
       vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
@@ -15127,6 +15587,16 @@ snapshots:
   expect-type@1.3.0: {}
 
   exsolve@1.1.0: {}
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
 
   fake-indexeddb@6.2.5: {}
 
@@ -15190,6 +15660,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -15238,7 +15712,7 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
-  fontless@0.2.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
+  fontless@0.2.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
       css-tree: 3.1.0
@@ -15252,7 +15726,7 @@ snapshots:
       pathe: 2.0.3
       ufo: 1.6.4
       unifont: 0.7.4
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
     optionalDependencies:
       vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -15276,7 +15750,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  fontless@0.2.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
+  fontless@0.2.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
       css-tree: 3.1.0
@@ -15290,7 +15764,7 @@ snapshots:
       pathe: 2.0.3
       ufo: 1.6.4
       unifont: 0.7.4
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
     optionalDependencies:
       vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -15361,11 +15835,23 @@ snapshots:
 
   get-port-please@3.2.0: {}
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@8.0.1: {}
 
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   giget@3.3.0: {}
 
@@ -15482,6 +15968,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   http-shutdown@1.2.2: {}
 
@@ -15600,7 +16093,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ipx@3.1.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1):
+  ip-address@10.4.0: {}
+
+  ipx@3.1.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1):
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       citty: 0.1.6
@@ -15616,7 +16111,7 @@ snapshots:
       sharp: 0.34.5
       svgo: 4.0.1
       ufo: 1.6.4
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
       xss: 1.0.15
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -15975,6 +16470,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@7.18.3: {}
+
   lru.min@1.1.4: {}
 
   magic-regexp@0.10.0:
@@ -16063,7 +16560,8 @@ snapshots:
 
   mdurl@2.0.0: {}
 
-  memory-pager@1.5.0: {}
+  memory-pager@1.5.0:
+    optional: true
 
   merge-stream@2.0.0: {}
 
@@ -16169,14 +16667,17 @@ snapshots:
     dependencies:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 14.2.0
+    optional: true
 
-  mongodb@6.21.0(@aws-sdk/credential-providers@3.1081.0):
+  mongodb@6.21.0(@aws-sdk/credential-providers@3.1081.0)(socks@2.8.9):
     dependencies:
       '@mongodb-js/saslprep': 1.4.13
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
     optionalDependencies:
       '@aws-sdk/credential-providers': 3.1081.0
+      socks: 2.8.9
+    optional: true
 
   motion-dom@12.42.2:
     dependencies:
@@ -16247,7 +16748,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
+  netmask@2.1.1: {}
+
+  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.4)
@@ -16268,7 +16771,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -16314,7 +16817,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -16356,7 +16859,7 @@ snapshots:
       - vite
       - webpack
 
-  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
+  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.4)
@@ -16377,7 +16880,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -16423,7 +16926,116 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      untyped: 2.0.0
+      unwasm: 0.5.3
+      youch: 4.1.1
+      youch-core: 0.3.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - better-sqlite3
+      - bun-types-no-globals
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - supports-color
+      - unloader
+      - uploadthing
+      - vite
+      - webpack
+
+  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@rollup/plugin-alias': 6.0.0(rollup@4.60.4)
+      '@rollup/plugin-commonjs': 29.0.2(rollup@4.60.4)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.60.4)
+      '@rollup/plugin-json': 6.1.0(rollup@4.60.4)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.4)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
+      '@rollup/plugin-terser': 1.0.0(rollup@4.60.4)
+      '@vercel/nft': 1.5.0(rollup@4.60.4)
+      archiver: 7.0.1
+      c12: 3.3.4(magicast@0.5.3)
+      chokidar: 5.0.0
+      citty: 0.2.2
+      compatx: 0.2.0
+      confbox: 0.2.4
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      croner: 10.0.1
+      crossws: 0.3.5
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))
+      defu: 6.1.7
+      destr: 2.0.5
+      dot-prop: 10.1.0
+      esbuild: 0.28.1
+      escape-string-regexp: 5.0.0
+      etag: 1.8.1
+      exsolve: 1.1.0
+      globby: 16.2.0
+      gzip-size: 7.0.0
+      h3: 1.15.11
+      hookable: 5.5.3
+      httpxy: 0.5.1
+      ioredis: 5.10.1
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      listhen: 1.10.0
+      magic-string: 0.30.21
+      magicast: 0.5.3
+      mime: 4.1.0
+      mlly: 1.8.2
+      node-fetch-native: 1.6.7
+      node-mock-http: 1.0.4
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      pretty-bytes: 7.1.0
+      radix3: 1.1.2
+      rollup: 4.60.4
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.4)
+      scule: 1.3.0
+      semver: 7.8.5
+      serve-placeholder: 2.0.2
+      serve-static: 2.2.1
+      source-map: 0.7.6
+      std-env: 4.2.0
+      ufo: 1.6.4
+      ultrahtml: 1.7.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unenv: 2.0.0-rc.24
+      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      unplugin-utils: 0.3.2
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -16536,18 +17148,18 @@ snapshots:
 
   nuxi@3.29.3: {}
 
-  nuxt-ai-ready@1.5.8(d032f294098e20c70584a0bd6d18cf49):
+  nuxt-ai-ready@1.5.8(b9f7d4c3979c8e5f41449f7bce3fca6e):
     dependencies:
       '@mdream/js': 1.5.5
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@nuxtjs/sitemap': 8.3.0(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      '@nuxtjs/sitemap': 8.3.0(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       citty: 0.2.2
       consola: 3.4.2
       defu: 6.1.7
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)
       mdream: 1.5.5
-      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.2(vue@3.5.40(typescript@6.0.3))
@@ -16622,7 +17234,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-link-checker@5.1.3(@nuxt/schema@4.5.0)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxt-link-checker@5.1.3(@nuxt/schema@4.5.0)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
@@ -16631,9 +17243,9 @@ snapshots:
       fuse.js: 7.5.0
       h3: 1.15.11
       magic-string: 1.0.0
-      nuxt: 4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3)
-      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt: 4.5.0(133916b78b4d7caedebb9e59d45f96aa)
+      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -16641,7 +17253,7 @@ snapshots:
       site-config-stack: 4.1.2(vue@3.5.40(typescript@6.0.3))
       ufo: 1.6.4
       ultrahtml: 1.7.0
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -16671,7 +17283,7 @@ snapshots:
       - vue
       - zod
 
-  nuxt-og-image@6.7.4(f3015b2e0de74325fb46c9afe8020464):
+  nuxt-og-image@6.7.4(a1399fcc221e84acb41f4dc9be5ed6ce):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -16690,8 +17302,8 @@ snapshots:
       magic-string: 1.0.0
       magicast: 0.5.3
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       nypm: 0.6.8
       object-identity: 0.2.3
       ofetch: 1.5.1
@@ -16708,12 +17320,12 @@ snapshots:
       ufo: 1.6.4
       ultrahtml: 1.7.0
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
     optionalDependencies:
       '@resvg/resvg-js': 2.6.2
       '@resvg/resvg-wasm': 2.6.2
-      fontless: 0.2.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      fontless: 0.2.1(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       playwright-core: 1.60.0
       satori: 0.28.2
       sharp: 0.34.5
@@ -16735,12 +17347,12 @@ snapshots:
       - vue
       - webpack
 
-  nuxt-schema-org@6.2.7(@nuxt/schema@4.5.0)(@unhead/vue@3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unhead@3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxt-schema-org@6.2.7(@nuxt/schema@4.5.0)(@unhead/vue@3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unhead@3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       defu: 6.1.7
-      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       pkg-types: 2.3.1
       ufo: 1.6.4
     optionalDependencies:
@@ -16758,7 +17370,7 @@ snapshots:
       - vite
       - vue
 
-  nuxt-seo-utils@8.3.2(@nuxt/schema@4.5.0)(@types/node@22.18.10)(@unhead/vue@3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(esbuild@0.28.1)(lightningcss@1.32.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(unhead@3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxt-seo-utils@8.3.2(@nuxt/schema@4.5.0)(@types/node@22.18.10)(@unhead/vue@3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(esbuild@0.28.1)(lightningcss@1.32.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(unhead@3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@unhead/bundler': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(unhead@3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -16768,9 +17380,9 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
       image-size: 2.0.2
-      nuxt: 4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3)
-      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt: 4.5.0(133916b78b4d7caedebb9e59d45f96aa)
+      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -16820,13 +17432,13 @@ snapshots:
       - unplugin
       - vue
 
-  nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       h3: 1.15.11
       nuxt-site-config-kit: 4.1.2(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue@3.5.40(typescript@6.0.3))
-      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.2(vue@3.5.40(typescript@6.0.3))
@@ -16843,19 +17455,19 @@ snapshots:
       - vue
       - zod
 
-  nuxt-skew-protection@1.3.1(a9c3bd3d7387e6b31d0f19d8d8319b52):
+  nuxt-skew-protection@1.3.1(55401d4f02bce1a26b06f80352076643):
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@nuxtjs/robots': 6.1.3(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      '@nuxtjs/robots': 6.1.3(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
       consola: 3.4.2
       cookie-es: 3.1.1
-      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       tinyexec: 1.2.4
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -16894,16 +17506,155 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt@4.5.0(9e2c98569c50f8e722d2aef5b4a88ea0):
+  nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa):
+    dependencies:
+      '@dxup/nuxt': 0.5.3(esbuild@0.28.1)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.0)(cac@6.7.14)(magicast@0.5.3)
+      '@nuxt/devtools': 3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxt/nitro-server': 4.5.0(4335eb9b62c8a43a2adb44176f3a9146)
+      '@nuxt/schema': 4.5.0
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))
+      '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
+      '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@vue/shared': 3.5.40
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 3.1.1
+      defu: 6.1.7
+      devalue: 5.8.1
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.0
+      fnv1a-64: 0.1.1
+      hookable: 6.1.1
+      ignore: 7.0.6
+      impound: 1.1.5(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 1.0.0
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nostics: 1.2.0
+      nypm: 0.6.8
+      object-identity: 0.2.3
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-walker: 1.0.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.5
+      pkg-types: 2.3.1
+      rolldown: 1.2.0
+      rolldown-string: 0.3.1(rolldown@1.2.0)
+      rou3: 0.9.1
+      scule: 1.3.0
+      semver: 7.8.5
+      std-env: 4.2.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      ultrahtml: 1.7.0
+      uncrypto: 0.1.3
+      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      undici: 8.7.0
+      unhead: 3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.40(typescript@6.0.3)
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+      '@types/node': 22.18.10
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@babel/plugin-syntax-typescript'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@modelcontextprotocol/sdk'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@rspack/core'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - better-sqlite3
+      - bufferutil
+      - bun-types-no-globals
+      - cac
+      - commander
+      - crossws
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxc-parser
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - unloader
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vue-tsc
+      - webpack
+      - xml2js
+      - yaml
+
+  nuxt@4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe):
     dependencies:
       '@dxup/nuxt': 0.5.3(esbuild@0.28.1)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.0)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.0(e1f2260672125d782067ee19ea61f533)
+      '@nuxt/nitro-server': 4.5.0(e01bd71ada403ae072a54d3bc61413fc)
       '@nuxt/schema': 4.5.0
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(9e2c98569c50f8e722d2aef5b4a88ea0))(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(39a5b60aea359d80f6dae8d4ef0ce4fe))(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
       '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@vue/shared': 3.5.40
       chokidar: 5.0.0
@@ -17033,16 +17784,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.5.0(9ed16452ae3a87615631e805d1fbe87b):
+  nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf):
     dependencies:
       '@dxup/nuxt': 0.5.3(esbuild@0.28.1)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.0)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.0(964fa8acb3122f68500aa64db34fcc55)
+      '@nuxt/nitro-server': 4.5.0(9deaf1e2abe9e09c056b7228dbd5cc41)
       '@nuxt/schema': 4.5.0
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(9ed16452ae3a87615631e805d1fbe87b))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
       '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@vue/shared': 3.5.40
       chokidar: 5.0.0
@@ -17172,146 +17923,7 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3):
-    dependencies:
-      '@dxup/nuxt': 0.5.3(esbuild@0.28.1)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.0)(cac@6.7.14)(magicast@0.5.3)
-      '@nuxt/devtools': 3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.0(6c8e8883c3d2dc98a87d147c44e64209)
-      '@nuxt/schema': 4.5.0
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
-      '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-      '@vue/shared': 3.5.40
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 3.1.1
-      defu: 6.1.7
-      devalue: 5.8.1
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.0
-      fnv1a-64: 0.1.1
-      hookable: 6.1.1
-      ignore: 7.0.6
-      impound: 1.1.5(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 1.0.0
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nostics: 1.2.0
-      nypm: 0.6.8
-      object-identity: 0.2.3
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-walker: 1.0.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.5
-      pkg-types: 2.3.1
-      rolldown: 1.2.0
-      rolldown-string: 0.3.1(rolldown@1.2.0)
-      rou3: 0.9.1
-      scule: 1.3.0
-      semver: 7.8.5
-      std-env: 4.2.0
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      ultrahtml: 1.7.0
-      uncrypto: 0.1.3
-      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      undici: 8.7.0
-      unhead: 3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      unrouting: 0.1.7
-      untyped: 2.0.0
-      vue: 3.5.40(typescript@6.0.3)
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 22.18.10
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@babel/plugin-syntax-typescript'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@modelcontextprotocol/sdk'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@rspack/core'
-      - '@unhead/cli'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - better-sqlite3
-      - bufferutil
-      - bun-types-no-globals
-      - cac
-      - commander
-      - crossws
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxc-parser
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - unloader
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vue-tsc
-      - webpack
-      - xml2js
-      - yaml
-
-  nuxtseo-shared@5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@5.3.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt-site-config@4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -17320,7 +17932,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3)
+      nuxt: 4.5.0(133916b78b4d7caedebb9e59d45f96aa)
       nypm: 0.6.8
       ofetch: 1.5.1
       pathe: 2.0.3
@@ -17331,7 +17943,7 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.40(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(dd05aa73f2cdfdcdbbe4f0ce0e6dfeb3))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.2(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - magic-string
@@ -17535,6 +18147,24 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@1.4.0: {}
@@ -17581,6 +18211,8 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
+
+  pend@1.2.0: {}
 
   perfect-debounce@1.0.0:
     optional: true
@@ -17901,6 +18533,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  progress@2.0.3: {}
+
   promise-limit@2.7.0: {}
 
   proper-lockfile@4.1.2:
@@ -17984,6 +18618,21 @@ snapshots:
       prosemirror-transform: 1.12.0
 
   proto-list@1.2.4: {}
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -18086,6 +18735,8 @@ snapshots:
   remeda@2.33.4: {}
 
   request-ip@3.3.0: {}
+
+  require-directory@2.1.1: {}
 
   requires-port@1.0.0: {}
 
@@ -18456,7 +19107,22 @@ snapshots:
 
   slugify@1.6.9: {}
 
+  smart-buffer@4.2.0: {}
+
   smob@1.5.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.4.0
+      smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
 
@@ -18472,6 +19138,7 @@ snapshots:
   sparse-bitfield@3.0.3:
     dependencies:
       memory-pager: 1.5.0
+    optional: true
 
   speakingurl@14.0.1:
     optional: true
@@ -18506,6 +19173,16 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
 
   string-width@4.2.3:
     dependencies:
@@ -18618,6 +19295,18 @@ snapshots:
       pump: 3.0.4
       tar-stream: 2.2.0
 
+  tar-fs@3.1.3:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 4.8.0
+      bare-path: 3.1.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -18642,6 +19331,14 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
 
   terminal-size@4.0.1: {}
 
@@ -18692,6 +19389,7 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+    optional: true
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -18943,7 +19641,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.4
 
-  unstorage@1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1):
+  unstorage@1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -18957,10 +19655,10 @@ snapshots:
       '@upstash/redis': 1.35.5
       '@vercel/kv': 3.0.0
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260712.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10))
       ioredis: 5.10.1
 
-  unstorage@1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1):
+  unstorage@1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -18974,7 +19672,24 @@ snapshots:
       '@upstash/redis': 1.35.5
       '@vercel/kv': 3.0.0
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))
+      ioredis: 5.10.1
+
+  unstorage@1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.3.6
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+    optionalDependencies:
+      '@upstash/redis': 1.35.5
+      '@vercel/kv': 3.0.0
+      aws4fetch: 1.0.20
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))
       ioredis: 5.10.1
 
   untun@0.1.3:
@@ -19286,7 +20001,8 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webidl-conversions@7.0.0: {}
+  webidl-conversions@7.0.0:
+    optional: true
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -19294,6 +20010,7 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -19342,7 +20059,7 @@ snapshots:
       '@ai-sdk/provider': 4.0.4
       ai: 7.0.48(zod@4.4.3)
 
-  wrangler@4.110.0(@cloudflare/workers-types@5.20260712.1):
+  wrangler@4.110.0(@cloudflare/workers-types@5.20260804.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)
@@ -19353,7 +20070,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260708.1
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260712.1
+      '@cloudflare/workers-types': 5.20260804.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil
@@ -19415,7 +20132,19 @@ snapshots:
 
   yaml@2.9.0: {}
 
+  yargs-parser@21.1.1: {}
+
   yargs-parser@22.0.0: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yargs@18.0.0:
     dependencies:
@@ -19425,6 +20154,11 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yjs@13.6.31:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@nuxt/eslint-plugin':
+      specifier: ^1.15.2
+      version: 1.15.2
     alchemy:
       specifier: 2.0.0-beta.68
       version: 2.0.0-beta.68
@@ -15,6 +18,24 @@ catalogs:
     drizzle-orm:
       specifier: 1.0.0-rc.4
       version: 1.0.0-rc.4
+    nuxt:
+      specifier: ^4.4.5
+      version: 4.5.0
+    oxfmt:
+      specifier: ^0.58.0
+      version: 0.58.0
+    oxlint:
+      specifier: ^1.73.0
+      version: 1.73.0
+    vitest:
+      specifier: ^4.1.6
+      version: 4.1.6
+    vue-tsc:
+      specifier: ^3.2.9
+      version: 3.2.9
+    zod:
+      specifier: latest
+      version: 4.4.3
 
 overrides:
   effect: 4.0.0-beta.102
@@ -34,14 +55,14 @@ importers:
     dependencies:
       nuxt:
         specifier: ^4.5.0
-        version: 4.5.0(90c8833e38f8aa1b67239bf44a487755)
+        version: 4.5.0(c09e0e84edcb85e2d0bbe3f2ae880fb9)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^5.20260804.1
         version: 5.20260804.1
       '@distilled.cloud/nuxt':
         specifier: ^0.17.1
-        version: 0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(90c8833e38f8aa1b67239bf44a487755))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(c09e0e84edcb85e2d0bbe3f2ae880fb9))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1)
@@ -294,8 +315,8 @@ importers:
         specifier: 'catalog:'
         version: 4.5.0(133916b78b4d7caedebb9e59d45f96aa)
       nuxt-umami:
-        specifier: ^3.2.1
-        version: 3.2.1(magicast@0.5.3)
+        specifier: https://github.com/bgervan/nuxt-umami/releases/download/v3.4.0-bg.2/nuxt-umami-3.4.0.tgz
+        version: https://github.com/bgervan/nuxt-umami/releases/download/v3.4.0-bg.2/nuxt-umami-3.4.0.tgz(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       oxfmt:
         specifier: 'catalog:'
         version: 0.58.0
@@ -4245,11 +4266,6 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@vercel/nft@1.5.0':
-    resolution: {integrity: sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==}
-    engines: {node: '>=20'}
-    hasBin: true
-
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
@@ -7293,8 +7309,9 @@ packages:
       pusher-js:
         optional: true
 
-  nuxt-umami@3.2.1:
-    resolution: {integrity: sha512-82cf3kcrMn4Iq0rJ2Blfl48AqLWqRubEpxOinOoxqW7taZAd5SgZcCdCj7y4qXSt0W5DhBYgaq4IboyGFHoVUQ==}
+  nuxt-umami@https://github.com/bgervan/nuxt-umami/releases/download/v3.4.0-bg.2/nuxt-umami-3.4.0.tgz:
+    resolution: {integrity: sha512-Lf+TnI0gM8Cw1eZDBEtejxIk2RsPf1Thv4OhJ7zobSyts+PhJZ902SkFPxgH5JdmkRDCVCPHk1jGrWKekiOQpQ==, tarball: https://github.com/bgervan/nuxt-umami/releases/download/v3.4.0-bg.2/nuxt-umami-3.4.0.tgz}
+    version: 3.4.0
 
   nuxt@4.5.0:
     resolution: {integrity: sha512-MbMAQFR9q8sDf80mp0v1sLtPuFDviSw7ntcBHPP0ok9phpirRy19NM9aDNRI6/12hU646BurrE0zCFJK0pq7NA==}
@@ -9970,14 +9987,14 @@ snapshots:
       - supports-color
       - vite
 
-  '@distilled.cloud/nuxt@0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(90c8833e38f8aa1b67239bf44a487755))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@distilled.cloud/nuxt@0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@distilled.cloud/cloudflare-runtime': 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
       '@distilled.cloud/framework-core': 0.17.1(effect@4.0.0-beta.102)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       effect: 4.0.0-beta.102
       fast-glob: 3.3.3
     optionalDependencies:
-      nuxt: 4.5.0(90c8833e38f8aa1b67239bf44a487755)
+      nuxt: 4.5.0(96c9a12831306dbf3c0a308051d7cbaf)
     transitivePeerDependencies:
       - '@distilled.cloud/cloudflare'
       - '@effect/platform-bun'
@@ -9988,14 +10005,14 @@ snapshots:
       - supports-color
       - vite
 
-  '@distilled.cloud/nuxt@0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@distilled.cloud/nuxt@0.17.1(patch_hash=70f477aa0d7dd4ff0d64fe778470762af4921b3b19dbd48b2adbe4a537608dbe)(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)(nuxt@4.5.0(c09e0e84edcb85e2d0bbe3f2ae880fb9))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@distilled.cloud/cloudflare-runtime': 0.17.1(@distilled.cloud/cloudflare@1.0.0-rc.2)(@effect/platform-bun@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.10.1))(effect@4.0.0-beta.102)
       '@distilled.cloud/framework-core': 0.17.1(effect@4.0.0-beta.102)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       effect: 4.0.0-beta.102
       fast-glob: 3.3.3
     optionalDependencies:
-      nuxt: 4.5.0(96c9a12831306dbf3c0a308051d7cbaf)
+      nuxt: 4.5.0(c09e0e84edcb85e2d0bbe3f2ae880fb9)
     transitivePeerDependencies:
       - '@distilled.cloud/cloudflare'
       - '@effect/platform-bun'
@@ -10994,7 +11011,7 @@ snapshots:
       debug: 4.4.3
       defu: 6.1.7
       exsolve: 1.1.0
-      fuse.js: 7.4.2
+      fuse.js: 7.5.0
       fzf: 0.5.2
       giget: 3.3.0
       jiti: 2.7.0
@@ -11043,6 +11060,18 @@ snapshots:
       - rolldown
       - unplugin
 
+  '@nuxt/devtools-kit@3.2.4(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      execa: 8.0.1
+      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+
   '@nuxt/devtools-kit@3.2.4(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -11077,6 +11106,51 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.1
       semver: 7.8.5
+
+  '@nuxt/devtools@3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
+    dependencies:
+      '@nuxt/devtools-kit': 3.2.4(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@nuxt/devtools-wizard': 3.2.4
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@vue/devtools-core': 8.1.2(vue@3.5.40(typescript@6.0.3))
+      '@vue/devtools-kit': 8.1.5
+      birpc: 4.0.0
+      consola: 3.4.2
+      destr: 2.0.5
+      error-stack-parser-es: 1.0.5
+      execa: 8.0.1
+      fast-npm-meta: 1.5.1
+      get-port-please: 3.2.0
+      hookable: 6.1.1
+      image-meta: 0.2.2
+      is-installed-globally: 1.0.0
+      launch-editor: 2.13.2
+      local-pkg: 1.2.1
+      magicast: 0.5.3
+      nypm: 0.6.8
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      semver: 7.8.5
+      simple-git: 3.36.0
+      sirv: 3.0.2
+      structured-clone-es: 2.0.0
+      tinyglobby: 0.2.17
+      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      vite-plugin-vue-tracer: 1.4.0(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      which: 6.0.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - magic-string
+      - oxc-parser
+      - rolldown
+      - supports-color
+      - unplugin
+      - utf-8-validate
+      - vue
 
   '@nuxt/devtools@3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
@@ -11371,6 +11445,36 @@ snapshots:
       - rolldown
       - unplugin
 
+  '@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))':
+    dependencies:
+      c12: 3.3.4(magicast@0.5.3)
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.1.0
+      ignore: 7.0.6
+      jiti: 2.7.0
+      klona: 2.0.6
+      mlly: 1.8.2
+      nostics: 1.2.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+      scule: 1.3.0
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+
   '@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))':
     dependencies:
       c12: 3.3.4(magicast@0.5.3)
@@ -11429,6 +11533,91 @@ snapshots:
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260804.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@12.11.1)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      vue: 3.5.40(typescript@6.0.3)
+      vue-bundle-renderer: 2.3.1
+      vue-devtools-stub: 0.1.0
+    optionalDependencies:
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@modelcontextprotocol/sdk'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - better-sqlite3
+      - bufferutil
+      - bun-types-no-globals
+      - crossws
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - idb-keyval
+      - ioredis
+      - lightningcss
+      - magic-string
+      - magicast
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - sqlite3
+      - supports-color
+      - typescript
+      - unloader
+      - unplugin
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - webpack
+      - xml2js
+
+  '@nuxt/nitro-server@4.5.0(77ebdb54158d1466139ffad1864450ef)':
+    dependencies:
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@vue/shared': 3.5.40
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      devalue: 5.8.1
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.0
+      h3: 1.15.11
+      impound: 1.1.5(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      nostics: 1.2.0
+      nuxt: 4.5.0(c09e0e84edcb85e2d0bbe3f2ae880fb9)
+      nypm: 0.6.8
+      ohash: 2.0.11
+      pathe: 2.0.3
+      rou3: 0.9.1
+      std-env: 4.2.0
+      ufo: 1.6.4
+      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
       vue: 3.5.40(typescript@6.0.3)
       vue-bundle-renderer: 2.3.1
       vue-devtools-stub: 0.1.0
@@ -11571,91 +11760,6 @@ snapshots:
       - webpack
       - xml2js
 
-  '@nuxt/nitro-server@4.5.0(b91ba14303c75dc2fd3391cc3ccd1e2c)':
-    dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-      '@vue/shared': 3.5.40
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      devalue: 5.8.1
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.0
-      h3: 1.15.11
-      impound: 1.1.5(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      nostics: 1.2.0
-      nuxt: 4.5.0(90c8833e38f8aa1b67239bf44a487755)
-      nypm: 0.6.8
-      ohash: 2.0.11
-      pathe: 2.0.3
-      rou3: 0.9.1
-      std-env: 4.2.0
-      ufo: 1.6.4
-      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
-      vue: 3.5.40(typescript@6.0.3)
-      vue-bundle-renderer: 2.3.1
-      vue-devtools-stub: 0.1.0
-    optionalDependencies:
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@modelcontextprotocol/sdk'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@unhead/cli'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - better-sqlite3
-      - bufferutil
-      - bun-types-no-globals
-      - crossws
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - idb-keyval
-      - ioredis
-      - lightningcss
-      - magic-string
-      - magicast
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - sqlite3
-      - supports-color
-      - typescript
-      - unloader
-      - unplugin
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - webpack
-      - xml2js
-
   '@nuxt/schema@4.5.0':
     dependencies:
       '@vue/shared': 3.5.40
@@ -11663,6 +11767,15 @@ snapshots:
       nostics: 1.2.0
       pathe: 2.0.3
       pkg-types: 2.3.1
+      std-env: 4.2.0
+
+  '@nuxt/telemetry@2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))':
+    dependencies:
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      citty: 0.2.2
+      consola: 3.4.2
+      ofetch: 2.0.0-alpha.3
+      rc9: 3.0.1
       std-env: 4.2.0
 
   '@nuxt/telemetry@2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))':
@@ -11905,7 +12018,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(90c8833e38f8aa1b67239bf44a487755))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
@@ -11922,7 +12035,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.0(90c8833e38f8aa1b67239bf44a487755)
+      nuxt: 4.5.0(96c9a12831306dbf3c0a308051d7cbaf)
       nypm: 0.6.8
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -11967,9 +12080,9 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(96c9a12831306dbf3c0a308051d7cbaf))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(c09e0e84edcb85e2d0bbe3f2ae880fb9))(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 5.1.6(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       autoprefixer: 10.5.4(postcss@8.5.20)
@@ -11984,7 +12097,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.0(96c9a12831306dbf3c0a308051d7cbaf)
+      nuxt: 4.5.0(c09e0e84edcb85e2d0bbe3f2ae880fb9)
       nypm: 0.6.8
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -12002,7 +12115,7 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
       rolldown: 1.2.0
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.4)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.4)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -13678,26 +13791,6 @@ snapshots:
       '@upstash/redis': 1.35.5
 
   '@vercel/nft@1.10.2(rollup@4.60.4)':
-    dependencies:
-      '@mapbox/node-pre-gyp': 2.0.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
-      async-sema: 3.1.1
-      bindings: 1.5.0
-      estree-walker: 2.0.2
-      glob: 13.0.6
-      graceful-fs: 4.2.11
-      node-gyp-build: 4.8.4
-      picomatch: 4.0.5
-      resolve-from: 5.0.0
-    transitivePeerDependencies:
-      - encoding
-      - rollup
-      - supports-color
-    optional: true
-
-  '@vercel/nft@1.5.0(rollup@4.60.4)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.0
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
@@ -16591,7 +16684,7 @@ snapshots:
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.4)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.4)
-      '@vercel/nft': 1.5.0(rollup@4.60.4)
+      '@vercel/nft': 1.10.2(rollup@4.60.4)
       archiver: 7.0.1
       c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
@@ -16700,7 +16793,7 @@ snapshots:
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.4)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.4)
-      '@vercel/nft': 1.5.0(rollup@4.60.4)
+      '@vercel/nft': 1.10.2(rollup@4.60.4)
       archiver: 7.0.1
       c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
@@ -16799,7 +16892,7 @@ snapshots:
       - vite
       - webpack
 
-  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
+  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(aws4fetch@1.0.20)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))(oxc-parser@0.140.0)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.4)
@@ -16809,7 +16902,7 @@ snapshots:
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.4)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.4)
-      '@vercel/nft': 1.5.0(rollup@4.60.4)
+      '@vercel/nft': 1.10.2(rollup@4.60.4)
       archiver: 7.0.1
       c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
@@ -16866,7 +16959,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@upstash/redis@1.35.5)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -17330,12 +17423,16 @@ snapshots:
       - vite
       - vue
 
-  nuxt-umami@3.2.1(magicast@0.5.3):
+  nuxt-umami@https://github.com/bgervan/nuxt-umami/releases/download/v3.4.0-bg.2/nuxt-umami-3.4.0.tgz(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))):
     dependencies:
-      '@nuxt/kit': 3.21.5(magicast@0.5.3)
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       request-ip: 3.3.0
     transitivePeerDependencies:
+      - magic-string
       - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
 
   nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa):
     dependencies:
@@ -17347,145 +17444,6 @@ snapshots:
       '@nuxt/schema': 4.5.0
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))
       '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(133916b78b4d7caedebb9e59d45f96aa))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
-      '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-      '@vue/shared': 3.5.40
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 3.1.1
-      defu: 6.1.7
-      devalue: 5.8.1
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.0
-      fnv1a-64: 0.1.1
-      hookable: 6.1.1
-      ignore: 7.0.6
-      impound: 1.1.5(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 1.0.0
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nostics: 1.2.0
-      nypm: 0.6.8
-      object-identity: 0.2.3
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-walker: 1.0.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.5
-      pkg-types: 2.3.1
-      rolldown: 1.2.0
-      rolldown-string: 0.3.1(rolldown@1.2.0)
-      rou3: 0.9.1
-      scule: 1.3.0
-      semver: 7.8.5
-      std-env: 4.2.0
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      ultrahtml: 1.7.0
-      uncrypto: 0.1.3
-      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      undici: 8.7.0
-      unhead: 3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      unrouting: 0.1.7
-      untyped: 2.0.0
-      vue: 3.5.40(typescript@6.0.3)
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 22.18.10
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@babel/plugin-syntax-typescript'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@modelcontextprotocol/sdk'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@rspack/core'
-      - '@unhead/cli'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - better-sqlite3
-      - bufferutil
-      - bun-types-no-globals
-      - cac
-      - commander
-      - crossws
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxc-parser
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - unloader
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vue-tsc
-      - webpack
-      - xml2js
-      - yaml
-
-  nuxt@4.5.0(90c8833e38f8aa1b67239bf44a487755):
-    dependencies:
-      '@dxup/nuxt': 0.5.3(esbuild@0.28.1)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
-      '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.0)(cac@6.7.14)(magicast@0.5.3)
-      '@nuxt/devtools': 3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.0(b91ba14303c75dc2fd3391cc3ccd1e2c)
-      '@nuxt/schema': 4.5.0
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(90c8833e38f8aa1b67239bf44a487755))(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.73.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue-tsc@3.2.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
       '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@vue/shared': 3.5.40
       chokidar: 5.0.0
@@ -17668,6 +17626,145 @@ snapshots:
       ultrahtml: 1.7.0
       uncrypto: 0.1.3
       unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      undici: 8.7.0
+      unhead: 3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.40(typescript@6.0.3)
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+      '@types/node': 22.18.10
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@babel/plugin-syntax-typescript'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@modelcontextprotocol/sdk'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@rspack/core'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - better-sqlite3
+      - bufferutil
+      - bun-types-no-globals
+      - cac
+      - commander
+      - crossws
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxc-parser
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - unloader
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vue-tsc
+      - webpack
+      - xml2js
+      - yaml
+
+  nuxt@4.5.0(c09e0e84edcb85e2d0bbe3f2ae880fb9):
+    dependencies:
+      '@dxup/nuxt': 0.5.3(esbuild@0.28.1)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.0)(cac@6.7.14)(magicast@0.5.3)
+      '@nuxt/devtools': 3.2.4(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxt/nitro-server': 4.5.0(77ebdb54158d1466139ffad1864450ef)
+      '@nuxt/schema': 4.5.0
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))
+      '@nuxt/vite-builder': 4.5.0(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.18.10)(esbuild@0.28.1)(eslint@10.4.0(jiti@2.7.0))(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(c09e0e84edcb85e2d0bbe3f2ae880fb9))(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.4))(terser@5.44.0)(tsx@4.23.0)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)
+      '@unhead/vue': 3.2.1(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.60.4)(typescript@6.0.3)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@vue/shared': 3.5.40
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 3.1.1
+      defu: 6.1.7
+      devalue: 5.8.1
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.0
+      fnv1a-64: 0.1.1
+      hookable: 6.1.1
+      ignore: 7.0.6
+      impound: 1.1.5(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 1.0.0
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nostics: 1.2.0
+      nypm: 0.6.8
+      object-identity: 0.2.3
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-walker: 1.0.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.5
+      pkg-types: 2.3.1
+      rolldown: 1.2.0
+      rolldown-string: 0.3.1(rolldown@1.2.0)
+      rou3: 0.9.1
+      scule: 1.3.0
+      semver: 7.8.5
+      std-env: 4.2.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      ultrahtml: 1.7.0
+      uncrypto: 0.1.3
+      unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
       undici: 8.7.0
       unhead: 3.2.1(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
       unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -18641,6 +18738,17 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.0
       '@rolldown/binding-win32-x64-msvc': 1.2.0
 
+  rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.4):
+    dependencies:
+      open: 11.0.0
+      picomatch: 4.0.5
+      source-map: 0.7.6
+      yargs: 18.0.0
+    optionalDependencies:
+      rolldown: 1.1.5
+      rollup: 4.60.4
+    optional: true
+
   rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.4):
     dependencies:
       open: 11.0.0
@@ -19275,6 +19383,13 @@ snapshots:
       rolldown: 1.2.0
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  unctx@3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))):
+    optionalDependencies:
+      magic-string: 1.0.0
+      oxc-parser: 0.140.0
+      rolldown: 1.2.0
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+
   unctx@3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))):
     optionalDependencies:
       magic-string: 1.0.0
@@ -19424,6 +19539,18 @@ snapshots:
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
+  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.28.1
+      rolldown: 1.1.5
+      rollup: 4.60.4
+      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
+    optional: true
+
   unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -19474,7 +19601,7 @@ snapshots:
       db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260712.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))
       ioredis: 5.10.1
 
-  unstorage@1.17.5(@upstash/redis@1.35.5)(@vercel/kv@3.0.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1):
+  unstorage@1.17.5(@upstash/redis@1.35.5)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10)))(ioredis@5.10.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -19486,7 +19613,6 @@ snapshots:
       ufo: 1.6.4
     optionalDependencies:
       '@upstash/redis': 1.35.5
-      '@vercel/kv': 3.0.0
       aws4fetch: 1.0.20
       db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(better-sqlite3@13.0.1)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260804.1)(@effect/sql-d1@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-mysql2@4.0.0-beta.102(@types/node@22.18.10)(effect@4.0.0-beta.102))(@effect/sql-pg@4.0.0-beta.102(effect@4.0.0-beta.102))(@effect/sql-sqlite-do@4.0.0-beta.104(effect@4.0.0-beta.102))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@upstash/redis@1.35.5)(better-sqlite3@13.0.1)(effect@4.0.0-beta.102)(mysql2@3.22.6(@types/node@22.18.10))(pg@8.22.0)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3))(mysql2@3.22.6(@types/node@22.18.10))
       ioredis: 5.10.1
@@ -19595,6 +19721,23 @@ snapshots:
       oxlint: 1.73.0
       typescript: 6.0.3
       vue-tsc: 3.2.9(typescript@6.0.3)
+
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      ansis: 4.2.0
+      debug: 4.4.3
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.2
+      vite: 8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite-dev-rpc: 1.1.0(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))
+    optionalDependencies:
+      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)))
+    transitivePeerDependencies:
+      - supports-color
 
   vite-plugin-inspect@11.3.3(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.60.4)(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0))))(vite@8.1.5(@types/node@22.18.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
 
 catalog:
   '@nuxt/eslint-plugin': '^1.15.2'
-  alchemy: '2.0.0-beta.67'
+  alchemy: '2.0.0-beta.68'
   effect: '4.0.0-beta.102'
   '@effect/platform-node': '4.0.0-beta.102'
   drizzle-kit: '1.0.0-rc.4'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,12 +2,12 @@ packages:
   - 'apps/*'
 
 catalog:
+  '@effect/platform-node': '4.0.0-beta.102'
   '@nuxt/eslint-plugin': '^1.15.2'
   alchemy: '2.0.0-beta.68'
-  effect: '4.0.0-beta.102'
-  '@effect/platform-node': '4.0.0-beta.102'
   drizzle-kit: '1.0.0-rc.4'
   drizzle-orm: '1.0.0-rc.4'
+  effect: '4.0.0-beta.102'
   nuxt: '^4.4.5'
   oxfmt: '^0.58.0'
   oxlint: '^1.73.0'
@@ -16,13 +16,6 @@ catalog:
   vue: 'latest'
   vue-tsc: '^3.2.9'
   zod: 'latest'
-
-overrides:
-  effect: 4.0.0-beta.102
-  '@effect/platform-node': 4.0.0-beta.102
-  '@effect/platform-bun': 4.0.0-beta.102
-  '@effect/sql-pg': 4.0.0-beta.102
-  typescript: 6.0.3
 
 ignoredBuiltDependencies:
   - '@parcel/watcher'
@@ -34,3 +27,12 @@ ignoredBuiltDependencies:
 onlyBuiltDependencies:
   - msgpackr-extract
   - workerd
+
+overrides:
+  '@effect/platform-bun': 4.0.0-beta.102
+  '@effect/platform-node': 4.0.0-beta.102
+  '@effect/sql-pg': 4.0.0-beta.102
+  effect: 4.0.0-beta.102
+  typescript: 6.0.3
+patchedDependencies:
+  '@distilled.cloud/nuxt@0.17.1': patches/@distilled.cloud__nuxt@0.17.1.patch


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Rewrites the Cloudflare deploy and local-infra path for both apps; production Worker packaging, bindings, cron/workflows, and SEO/analytics behavior all change together.
> 
> **Overview**
> Moves **CMS** and **web** from prebuilt `Cloudflare.Worker` + `Command.Build` to **`Cloudflare.Website.Nuxt`** (`@distilled.cloud/nuxt`), with bindings and env wired in `infra/workers.ts`. Drops **`Command` providers**, root **`wrangler`**, and Nitro **`cloudflare_module` / wrangler** blocks from both Nuxt apps (including CMS dev wrangler.json generation). CMS **`dev`/`deploy`** scripts call **`alchemy dev`/`deploy`**; docs describe **`pnpm dev:infra`** for wrangler-free local bindings.
> 
> Adds a **pnpm patch** so `@distilled.cloud/nuxt` honors stable **`devServer.port`** (3000/3001). In Alchemy dev, **`CONTENT_GENERATION`** workflow binding is omitted (fallback poller); deploy keeps workflow via `exports.cloudflare.ts`.
> 
> **Strapi import:** `getStrapiImportStatus` auto-heals stale **`running`** state when the lock is missing/expired.
> 
> **Web:** non-prod stages get **`NUXT_SITE_INDEXABLE=false`** / `site.indexable: false` and **`useLoadMeta`** emits **`noindex, nofollow`**; prod gets Umami **host** + id; Umami bumped to a **custom build** with **Core Web Vitals** tracking; web build uses **`--preset cloudflare_module`** explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b96200949aa7ece1b8b40061d0da538ea8706613. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->